### PR TITLE
Add provenance only workflow

### DIFF
--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -46,6 +46,7 @@ const (
 
 // TODO: remove builder.yml
 var trustedReusableWorkflows = map[string]bool{
+	"slsa-framework/slsa-github-generator/.github/workflows/slsa2_provenance.yml": true,
 	"slsa-framework/slsa-github-generator-go/.github/workflows/slsa3_builder.yml": true,
 	"slsa-framework/slsa-github-generator-go/.github/workflows/builder.yml":       true,
 }


### PR DESCRIPTION
Allow slsa-verifier to verify provenance from the slsa-github-generator workflow.
https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/workflows/slsa2_provenance.yml