### PR TITLE
✨ Add trusted builder

### DIFF
--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -49,6 +49,7 @@ var trustedReusableWorkflows = map[string]bool{
 	"slsa-framework/slsa-github-generator/.github/workflows/slsa2_provenance.yml": true,
 	"slsa-framework/slsa-github-generator-go/.github/workflows/slsa3_builder.yml": true,
 	"slsa-framework/slsa-github-generator-go/.github/workflows/builder.yml":       true,
+	"slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml": true,
 }
 
 var (


### PR DESCRIPTION
The Go builders have been migrated into https://github.com/slsa-framework/slsa-github-generator, so we need to add them to the list of trusted builders.

Note: We'll remove the other ones before the v1 release