### PR TITLE
release: Release v1.0.0! Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ go run . <options>
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v0.0.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v0.0.1)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.0)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,2 +1,5 @@
+### [v1.0.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.0)
+2aeaea90f65d20570b57aaf3fadcb2d23dd5c1edbf1432e0addc17624681a269 slsa-verifier-linux-amd64
+
 ### [v0.0.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v0.0.1)
 60c91c9d5b9a059e37ac46da316f20c81da335b5d00e1f74d03dd50f819694bd slsa-verifier-linux-amd64


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This file updates documentation for slsa-verifier releaes v1.0.0
https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.0

To verify the release, 

1. Download the binary [slsa-verifier-linux-amd64](https://github.com/slsa-framework/slsa-verifier/releases/download/v1.0.0/slsa-verifier-linux-amd64) and provenance [slsa-verifier-linux-amd64.intoto.jsonl](https://github.com/slsa-framework/slsa-verifier/releases/download/v1.0.0/slsa-verifier-linux-amd64.intoto.jsonl) from [Assets](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.0)
2. Close this repository, and run the verifier
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
# $ (Optional: git checkout v1.0.0)
$ go run . -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.0.0
```
3. Verify the hash of the binary: it should be
```
sha256sum ~/Downloads/slsa-verifier-linux-amd64
2aeaea90f65d20570b57aaf3fadcb2d23dd5c1edbf1432e0addc17624681a269  /home/asraa/Downloads/slsa-verifier-linux-amd64
```

which matches the value in the verified provenance:
```
$ cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```