### PR TITLE
release: update to release 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ You have two options to install the verifier.
 
 #### Option 1: Install via go
 ```
-$ go install github.com/slsa-framework/slsa-verifier@v1.0.0
+$ go install github.com/slsa-framework/slsa-verifier@v1.1.0
 $ slsa-verifier <options>
 ```
 
 #### Option 2: Compile manually
 ```
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ cd slsa-verifier && git checkout tags/v0.0.1
+$ cd slsa-verifier && git checkout v1.1.0
 $ go run . <options>
 ```
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.0)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 
@@ -76,13 +76,13 @@ $ go run . --help
 ### Example
 
 ```bash
-$ go run . -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.0.0
-Verified signature against tlog entry index 2592016 at URL: https://rekor.sigstore.dev/api/v1/log/entries/d77621eaf1de74592546f773192f49ed995e8b12f2e5eeed02057ae32b24aa95
+$ go run . -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.1.0
+Verified signature against tlog entry index 2721439 at URL: https://rekor.sigstore.dev/api/v1/log/entries/0bfb8005ef0ccb0bdddc073072ceef03225b7e749eab97fb862b1cdfbe72b353
 Signing certificate information:
  {
 	"caller": "slsa-framework/slsa-verifier",
-	"commit": "c1b6db643d6134285dc929206fdcfa3712a877eb",
-	"job_workflow_ref": "/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v0.0.1",
+	"commit": "5875b0a74f4c04e1f123a3ad81d6c7c5a86860ce",
+	"job_workflow_ref": "/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.1.0",
 	"trigger": "push",
 	"issuer": "https://token.actions.githubusercontent.com"
 }

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,3 +1,6 @@
+### [v1.1.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0)
+14360688de2d294e9cda7b9074ab7dcf02d5c38f2874f6c95d4ad46e300c3e53 slsa-verifier-linux-amd64
+
 ### [v1.0.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.0)
 2aeaea90f65d20570b57aaf3fadcb2d23dd5c1edbf1432e0addc17624681a269 slsa-verifier-linux-amd64
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This sets the expected sha256 of the v1.1.0 slsa-verifier released binary.

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ (Optional: git checkout v1.1.0)
$ go run . -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.1.0
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```