### PR TITLE
v1.1.1: add v1.1.1 sha and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ You have two options to install the verifier.
 
 #### Option 1: Install via go
 ```
-$ go install github.com/slsa-framework/slsa-verifier@v1.1.0
+$ go install github.com/slsa-framework/slsa-verifier@v1.1.1
 $ slsa-verifier <options>
 ```
 
 #### Option 2: Compile manually
 ```
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ cd slsa-verifier && git checkout v1.1.0
+$ cd slsa-verifier && git checkout v1.1.1
 $ go run . <options>
 ```
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.1)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 
@@ -76,13 +76,13 @@ $ go run . --help
 ### Example
 
 ```bash
-$ go run . -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.1.0
-Verified signature against tlog entry index 2721439 at URL: https://rekor.sigstore.dev/api/v1/log/entries/0bfb8005ef0ccb0bdddc073072ceef03225b7e749eab97fb862b1cdfbe72b353
+$ go run . -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.1.1
+Verified signature against tlog entry index 2727751 at URL: https://rekor.sigstore.dev/api/v1/log/entries/8f3d898ef17d9c4c028fe3da09fb786c900bf786361e75432f325b4848fdba24
 Signing certificate information:
  {
 	"caller": "slsa-framework/slsa-verifier",
 	"commit": "5875b0a74f4c04e1f123a3ad81d6c7c5a86860ce",
-	"job_workflow_ref": "/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.1.0",
+	"job_workflow_ref": "/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.1.1",
 	"trigger": "push",
 	"issuer": "https://token.actions.githubusercontent.com"
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,7 @@ Follow the steps:
 ```
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
 $ cd slsa-verifier
-# $ (Optional: git checkout tags/v1.0.0)
+# $ (Optional: git checkout tags/v1.1.1)
 $ go run . -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag vX.Y.Z
 ```
 

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,3 +1,6 @@
+### [v1.1.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.1)
+f92fc4e571949c796d7709bb3f0814a733124b0155e484fad095b5ca68b4cb21 slsa-verifier-linux-amd64
+
 ### [v1.1.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0)
 14360688de2d294e9cda7b9074ab7dcf02d5c38f2874f6c95d4ad46e300c3e53 slsa-verifier-linux-amd64
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Leftover work, just caught..

This sets the expected sha256 of the v1.1.1 slsa-verifier released binary.

How to LGTM this PR (I'll work on a proper doc for this in https://github.com/slsa-framework/slsa-github-generator/issues/112):

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.1
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ (Optional: git checkout tags/v1.1.1)
$ go run . -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.1.1
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum