### PR TITLE
release: add notes for release v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ You have two options to install the verifier.
 
 #### Option 1: Install via go
 ```
-$ go install github.com/slsa-framework/slsa-verifier@v1.1.1
+$ go install github.com/slsa-framework/slsa-verifier@v1.2.0
 $ slsa-verifier <options>
 ```
 
 #### Option 2: Compile manually
 ```
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ cd slsa-verifier && git checkout v1.1.1
+$ cd slsa-verifier && git checkout v1.2.0
 $ go run . <options>
 ```
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.1)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 
@@ -76,9 +76,9 @@ $ go run . --help
 ### Example
 
 ```bash
-$ go run . -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.1.1
-Verified signature against tlog entry index 2727751 at URL: https://rekor.sigstore.dev/api/v1/log/entries/8f3d898ef17d9c4c028fe3da09fb786c900bf786361e75432f325b4848fdba24
-Verified build using builder https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.1.0 at commit 76a59d8413f27259b97298da91bbb6511fc775d1
+$ go run . -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.2.0
+Verified signature against tlog entry index 3027785 at URL: https://rekor.sigstore.dev/api/v1/log/entries/0cdff5b6a013379f9c1c5c6c598ad73c60de5acd969ba70ea2e874098b6e789f
+Verified build using builder https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.1.1 at commit fb9aeaf6384fd588e56ad90978fe025b3fd44849
 PASSED: Verified SLSA provenance
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,25 @@ This is a  document to describe the release process for the verifier.
 
 ## Publish release
 
+Major and minor releases are released directly from the `main` branch. Patch versions are released from the `release/vX.Y` branch.
+
+### New major or minor release
+
 Create a new tag for the official generator via [slsa-framework/slsa-verifier/releases/new](https://github.com/slsa-framework/slsa-verifier/releases/new). 
+
+Use a "canonical" semantic version without metadata `vX.Y.Z`.
+
+Set the title to `vX.Y.Z`.
+
+Click `Publish release`.
+
+This will trigger a release workflow: wait until it completes and generates the binary and the provenance.
+
+From the repository landing page, use the branch drop-down to create a branch from the tagged release with the format `release/vX.Y`. This will be used for backporting critical fixes and releases patch versions.
+
+### New patch release
+
+Critical patch fixes are released from the `release/vX.Y` branch. Once the backported fix has been merged, create a new tag for the official generator via [slsa-framework/slsa-verifier/releases/new](https://github.com/slsa-framework/slsa-verifier/releases/new). Use the `release/vX.Y` branch as the Target.
 
 Use a "canonical" semantic version without metadata `vX.Y.Z`.
 
@@ -37,6 +55,8 @@ $ cd slsa-verifier
 # $ (Optional: git checkout tags/v1.1.1)
 $ go run . -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag vX.Y.Z
 ```
+
+You should include the `-branch release/vX.Y` for patch version releases.
 
 If the provenance verification fails, delete the release and the tag. Otherwise, continue.
 

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,8 +1,14 @@
+### [v1.2.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0)
+37db23392c7918bb4e243cdb097ed5f9d14b9b965dc1905b25bc2d1c0c91bf3d slsa-verifier-linux-amd64
+
 ### [v1.1.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.1)
 f92fc4e571949c796d7709bb3f0814a733124b0155e484fad095b5ca68b4cb21 slsa-verifier-linux-amd64
 
 ### [v1.1.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0)
 14360688de2d294e9cda7b9074ab7dcf02d5c38f2874f6c95d4ad46e300c3e53 slsa-verifier-linux-amd64
+
+### [v1.0.2](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.2)
+bcefa5173ad84fbb10d3aeae95c1087f6a61e51836b932c60be85c78d570c403 slsa-verifier-linux-amd64
 
 ### [v1.0.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.1)
 e14616a4eec58f082fd6bea05de02dd9eba193379ddb15b5eb7e7e3880d0ccec slsa-verifier-linux-amd64


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This sets the expected sha256 of the v1.2.0 slsa-verifier released binary.

How to LGTM this PR (I'll work on a proper doc for this in https://github.com/slsa-framework/slsa-github-generator/issues/112):

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ (Optional: git checkout tags/v1.2.0)
$ go run . -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -source github.com/slsa-framework/slsa-verifier -tag v1.2.0
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```

The output hash should be the hash I'm updating to in this PR. If they match, LGTM. If they don't, someone tampered with the released binary and don't LGTM

-----------------
Also sets missing v1.0.2

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.2
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ (Optional: git checkout tags/v1.0.2)
$ go run . -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -source github.com/slsa-framework/slsa-verifier -tag v1.0.2 -branch release/v1.0
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```