### PR TITLE
release: release v1.3.0 of verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ You have two options to install the verifier.
 
 #### Option 1: Install via go
 ```
-$ go install github.com/slsa-framework/slsa-verifier@v1.2.0
+$ go install github.com/slsa-framework/slsa-verifier@v1.3.0
 $ slsa-verifier <options>
 ```
 
 #### Option 2: Compile manually
 ```
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ cd slsa-verifier && git checkout v1.2.0
-$ go run . <options>
+$ cd slsa-verifier && git checkout v1.3.0
+$ go run ./cli/slsa-verifier <options>
 ```
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 
@@ -55,7 +55,7 @@ Below is a list of options currently supported. Note that signature verification
 
 ```bash
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ go run . --help
+$ go run ./cli/slsa-verifier --help
  Usage of ./slsa-verifier:
   -artifact-path string
     	path to an artifact to verify
@@ -76,9 +76,9 @@ $ go run . --help
 ### Example
 
 ```bash
-$ go run . -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.2.0
-Verified signature against tlog entry index 3027785 at URL: https://rekor.sigstore.dev/api/v1/log/entries/0cdff5b6a013379f9c1c5c6c598ad73c60de5acd969ba70ea2e874098b6e789f
-Verified build using builder https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.1.1 at commit fb9aeaf6384fd588e56ad90978fe025b3fd44849
+$ go run ./cli/slsa-verifier -artifact-path ~/Downloads/slsa-verifier-linux-amd64 -provenance ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.3.0
+Verified signature against tlog entry index 3189970 at URL: https://rekor.sigstore.dev/api/v1/log/entries/206071d5ca7a2346e4db4dcb19a648c7f13b4957e655f4382b735894059bd199
+Verified build using builder https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.2.0 at commit 5bb13ef508b2b8ded49f9264d7712f1316830d10
 PASSED: Verified SLSA provenance
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,7 +53,7 @@ Follow the steps:
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
 $ cd slsa-verifier
 # $ (Optional: git checkout tags/v1.1.1)
-$ go run . -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag vX.Y.Z
+$ go run ./cli/slsa-verifier -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag vX.Y.Z
 ```
 
 You should include the `-branch release/vX.Y` for patch version releases.

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,3 +1,6 @@
+### [v1.3.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0)
+1326430d044e8a9522c51e5f721e237b5f75acb6b4e518d129f669403cf7a79a slsa-verifier-linux-amd64
+
 ### [v1.2.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0)
 37db23392c7918bb4e243cdb097ed5f9d14b9b965dc1905b25bc2d1c0c91bf3d slsa-verifier-linux-amd64
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This sets the expected sha256 of the v1.3.0 slsa-verifier released binary.

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ (Optional: git checkout tags/v1.3.0)
$ go run ./cli/slsa-verifier -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.3.0
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```

The output hash should be the hash I'm updating to in this PR. If they match, LGTM. If they don't, someone tampered with the released binary and don't LGTM