### PR TITLE
release: add release v1.0.3

### DIFF
--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -10,6 +10,9 @@ f92fc4e571949c796d7709bb3f0814a733124b0155e484fad095b5ca68b4cb21 slsa-verifier-l
 ### [v1.1.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0)
 14360688de2d294e9cda7b9074ab7dcf02d5c38f2874f6c95d4ad46e300c3e53 slsa-verifier-linux-amd64
 
+### [v1.0.3](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.3)
+5da115ab7f90f3e8a8b30c74820b4b7dd032afebef7cd912be23acb9fbd37d0b slsa-verifier-linux-amd64
+
 ### [v1.0.2](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.2)
 bcefa5173ad84fbb10d3aeae95c1087f6a61e51836b932c60be85c78d570c403 slsa-verifier-linux-amd64
 


### PR DESCRIPTION
This sets the expected sha256 of the v1.0.3 slsa-verifier released binary.

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.3
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ (Optional: git checkout tags/v1.0.3)
$ go run ./cli/slsa-verifier -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag v1.0.3
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```

The output hash should be the hash I'm updating to in this PR. If they match, LGTM. If they don't, someone tampered with the released binary and don't LGTM


Signed-off-by: Asra Ali <asraa@google.com>