### PR TITLE
cli: silence usage on errors

### DIFF
--- a/cli/slsa-verifier/main.go
+++ b/cli/slsa-verifier/main.go
@@ -34,6 +34,7 @@ For more information on SLSA, visit https://slsa.dev`,
 	c.AddCommand(verifyImageCmd())
 	// We print our own errors and usage in the check function.
 	c.SilenceErrors = true
+	c.SilenceUsage = true
 	return c
 }
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/sigstore/cosign v1.11.1
 	github.com/slsa-framework/slsa-github-generator v1.2.0
+	github.com/spf13/cobra v1.5.0
 	github.com/transparency-dev/merkle v0.0.1
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 )
@@ -168,7 +169,6 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/cobra v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.12.0 // indirect


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Otherwise, when `RunE` returns an error, we also print the usage, which is, at that point, correct: e.g.

```
$ go run ./cli/slsa-verifier verify-image ghcr.io/slsa-framework/example-package.e2e.container.workflow_dispatch.main.default.slsa3@sha256:c8d763cff21aaaee7ae925416ba8627dcb05dd38ecf48683249f4ef5f76f0155 --source-uri github.com/slsa-framework/example-package --print-provenance --source-tag v1.2.3
FAILED: SLSA verification failed: no valid attestations found on OCI registry: expected tag 'refs/tags/v1.2.3', got '': tag used to generate the binary does not match provenance
Usage:
  slsa-verifier verify-image [flags]

Flags:
      --build-workflow-input map[]    [optional] a workflow input provided by a user at trigger time in the format 'key=value'. (Only for 'workflow_dispatch' events on GitHub Actions). (default map[])
      --builder-id string             EXPERIMENTAL: the unique builder ID who created the provenance
  -h, --help                          help for verify-image
      --print-provenance              print the verified provenance to stdout
      --provenance-path string        path to a provenance file
      --source-branch string          [optional] expected branch the binary was compiled from
      --source-tag string             [optional] expected tag the binary was compiled from
      --source-uri string             expected source repository that should have produced the binary, e.g. github.com/some/repo
      --source-versioned-tag string   [optional] expected version the binary was compiled from. Uses semantic version to match the tag

no valid attestations found on OCI registry: expected tag 'refs/tags/v1.2.3', got '': tag used to generate the binary does not match provenance
exit status 1
```