### PR TITLE
fix(backport/v1.1): make client shard aware when verifying entries on inactive shards

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -309,7 +309,7 @@ func Test_runVerify(t *testing.T) {
 			name:      "rekor upload bypassed",
 			artifact:  "binary-linux-amd64-no-tlog-upload",
 			source:    "github.com/slsa-framework/example-package",
-			err:       pkg.ErrorRekorSearch,
+			err:       pkg.ErrorNoValidRekorEntries,
 			noversion: true,
 		},
 		{
@@ -323,7 +323,7 @@ func Test_runVerify(t *testing.T) {
 			name:      "malicious: invalid signature expired certificate",
 			artifact:  "binary-linux-amd64-expired-cert",
 			source:    "github.com/slsa-framework/example-package",
-			err:       pkg.ErrorRekorSearch,
+			err:       pkg.ErrorNoValidRekorEntries,
 			noversion: true,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Backport shard-aware fix to v1.1: allows searching through inactive shard's STHs. when verifying entries consistency with an STH.