### PR TITLE
release: add release v1.3.1 and v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,20 @@ You have two options to install the verifier.
 
 #### Option 1: Install via go
 ```
-$ go install github.com/slsa-framework/slsa-verifier/cli/slsa-verifier@v1.3.0
+$ go install github.com/slsa-framework/slsa-verifier/cli/slsa-verifier@v1.3.1
 $ slsa-verifier <options>
 ```
 
 #### Option 2: Compile manually
 ```
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ cd slsa-verifier && git checkout v1.3.0
+$ cd slsa-verifier && git checkout v1.3.1
 $ go run ./cli/slsa-verifier <options>
 ```
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.1)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,8 +52,8 @@ Follow the steps:
 ```
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
 $ cd slsa-verifier
-# $ (Optional: git checkout tags/v1.1.1)
-$ go run ./cli/slsa-verifier -artifact-path slsa-verifier-linux-amd64 -provenance slsa-verifier-linux-amd64.intoto.jsonl -source github.com/slsa-framework/slsa-verifier -tag vX.Y.Z
+# $ (Optional: git checkout tags/v1.1.1: you may need to change the command below)
+$ go run ./cli/slsa-verifier verify-artifact ~/Downloads/slsa-verifier-linux-amd64 --provenance-path ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl --source-uri github.com/slsa-framework/slsa-verifier --source-tag vX.Y.Z
 ```
 
 You should include the `-branch release/vX.Y` for patch version releases.

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,5 +1,11 @@
+### [v1.3.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.1)
+065714d01ba36c81fb11aa7031597a77b08491eb341bac8efc3e452f5d5ed4bd slsa-verifier-linux-amd64
+
 ### [v1.3.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0)
 1326430d044e8a9522c51e5f721e237b5f75acb6b4e518d129f669403cf7a79a slsa-verifier-linux-amd64
+
+### [v1.2.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.1)
+edd1d430429fa3dfaf249d7ec805891a4b7332ea1d17d23f9d20bc6f4aeebe04 slsa-verifier-linux-amd64
 
 ### [v1.2.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0)
 37db23392c7918bb4e243cdb097ed5f9d14b9b965dc1905b25bc2d1c0c91bf3d slsa-verifier-linux-amd64


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Waiting on https://github.com/slsa-framework/slsa-verifier/pull/287 for release/v1.1 branch.

To verify these hashes, do the following for https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.1 and https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.1

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.1 (or the other)
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$  go run ./cli/slsa-verifier verify-artifact ~/Downloads/slsa-verifier-linux-amd64 --provenance-path ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl --source-uri github.com/slsa-framework/slsa-verifier --source-tag v1.3.1 --source-branch release/v1.3
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```