### PR TITLE
fix: env vars are case sensitive in configuration

### DIFF
--- a/.github/config-release.yml
+++ b/.github/config-release.yml
@@ -14,4 +14,4 @@ binary: slsa-verifier-{{ .Os }}-{{ .Arch }}
 dir: ./cli/slsa-verifier
 
 ldflags:
-  - "-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.Version }}"
+  - "-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Tested with the build-dry command, before and after.

```
asraa@asraa1:~/git/slsa-verifier$  ~/Downloads/slsa-builder-go-linux-amd64  build --dry .github/config-release.yml VERSION:
&{linux amd64 <nil> 0xc0005880f0 map[CGO_ENABLED:0 GO111MODULE:on] [-trimpath -tags=netgo] [-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.Version }}] slsa-verifier-{{ .Os }}-{{ .Arch }}}
&{linux amd64 <nil> 0xc000155700 map[CGO_ENABLED:0 GO111MODULE:on] [-trimpath -tags=netgo] [-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.Version }}] slsa-verifier-{{ .Os }}-{{ .Arch }}}
arg env: VERSION:
env variable empty or not set: {{ .Env.Version }}bash: syntax error near unexpected token `&'
asraa@asraa1:~/git/slsa-verifier$ ~/Downloads/slsa-builder-go-linux-amd64 build --dry .github/config-release.yml VERSION:
&{linux amd64 <nil> 0xc0005880f0 map[CGO_ENABLED:0 GO111MODULE:on] [-trimpath -tags=netgo] [-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}] slsa-verifier-{{ .Os }}-{{ .Arch }}}
&{linux amd64 <nil> 0xc000596740 map[CGO_ENABLED:0 GO111MODULE:on] [-trimpath -tags=netgo] [-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}] slsa-verifier-{{ .Os }}-{{ .Arch }}}
arg env: VERSION:
::set-output name=go-binary-name::slsa-verifier-linux-amd64
::set-output name=go-command::WyIvdXNyL2xvY2FsL2dvL2Jpbi9nbyIsImJ1aWxkIiwiLW1vZD12ZW5kb3IiLCItdHJpbXBhdGgiLCItdGFncz1uZXRnbyIsIi1sZGZsYWdzPS1YIHNpZ3MuazhzLmlvL3JlbGVhc2UtdXRpbHMvdmVyc2lvbi5naXRWZXJzaW9uPSIsIi1vIiwic2xzYS12ZXJpZmllci1saW51eC1hbWQ2NCJd
::set-output name=go-env::WyJHT09TPWxpbnV4IiwiR09BUkNIPWFtZDY0IiwiR08xMTFNT0RVTEU9b24iLCJDR09fRU5BQkxFRD0wIl0=
::set-output name=go-working-dir::/home/asraa/git/slsa-verifier/cli/slsa-verifier
```