### PR TITLE
Add optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Usage:
 
 Flags:
       --build-workflow-input map[]    [optional] a workflow input provided by a user at trigger time in the format 'key=value'. (Only for 'workflow_dispatch' events). (default map[])
-      --builder-id string             the unique builder ID who created the provenance
+      --builder-id string             [optional] the unique builder ID who created the provenance
   -h, --help                          help for verify-artifact
-      --print-provenance              print the verified provenance to stdout
+      --print-provenance              [optional] print the verified provenance to stdout
       --provenance-path string        path to a provenance file
       --source-branch string          [optional] expected branch the binary was compiled from
       --source-tag string             [optional] expected tag the binary was compiled from

--- a/cli/slsa-verifier/verify/options.go
+++ b/cli/slsa-verifier/verify/options.go
@@ -50,7 +50,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(&o.BuildWorkflowInputs, "build-workflow-input",
 		"[optional] a workflow input provided by a user at trigger time in the format 'key=value'. (Only for 'workflow_dispatch' events on GitHub Actions).")
 
-	cmd.Flags().StringVar(&o.BuilderID, "builder-id", "", "the unique builder ID who created the provenance")
+	cmd.Flags().StringVar(&o.BuilderID, "builder-id", "", "[optional] the unique builder ID who created the provenance")
 
 	/* Source options */
 	cmd.Flags().StringVar(&o.SourceURI, "source-uri", "",
@@ -68,7 +68,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 		"path to a provenance file")
 
 	cmd.Flags().BoolVar(&o.PrintProvenance, "print-provenance", false,
-		"print the verified provenance to stdout")
+		"[optional] print the verified provenance to stdout")
 
 	cmd.MarkFlagRequired("source-uri")
 	cmd.MarkFlagsMutuallyExclusive("source-versioned-tag", "source-tag")


### PR DESCRIPTION
This adds missing [optional] annotations to flags in the verify-artifact --help message.

Alternatively, we could just indicate what flags are [required] - there are only two of them - and remove all the [optional] noise from all other flags.