### PR TITLE
release/v1.0: fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions: read-all
 jobs:
   builder:
     permissions:
+      actions: read # For the detection of GitHub Actions environment.
       id-token: write # For signing.
       contents: write # For asset uploads.
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.2.1


### PR DESCRIPTION
The update to builder v1.2.1 requires an update in the permissions (to detect the env)