### PR TITLE
releases: add new releases to SHA256SUM.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ ________
 - [Artifacts](#artifacts-1)
 - [Containers](#containers-1)
 
+[Known Issues](#known-issues)
+
 [Technical design](#technial-design)
 - [Blog posts](#blog-posts)
 - [Specifications](#specifications)
@@ -159,6 +161,22 @@ PASSED: Verified SLSA provenance
 The verified in-toto statement may be written to stdout with the `--print-provenance` flag to pipe into policy engines.
 
 Note that `--source-uri` supports GitHub repository URIs like `github.com/$OWNER/$REPO` when the build was enabled with a Cloud Build [GitHub trigger](https://cloud.google.com/build/docs/automating-builds/github/build-repos-from-github). Otherwise, the build provenance will contain the name of the Cloud Storage bucket used to host the source files, usually of the form `gs://[PROJECT_ID]_cloudbuild/source` (see [Running build](https://cloud.google.com/build/docs/running-builds/submit-build-via-cli-api#running_builds)). We recommend using GitHub triggers in order to preserve the source provenance and valiate that the source came from an expected, version-controlled repository. You *may* match on the fully-qualified tar like `gs://[PROJECT_ID]_cloudbuild/source/1665165360.279777-955d1904741e4bbeb3461080299e929a.tgz`.
+
+## Known Issues
+
+### tuf: invalid key
+
+This will occur only when verifying provenance generated with GitHub Actions.
+
+**Affected versions:** v1.3.0-v1.3.1, v1.2.0-v1.2.1, v1.1.0-v1.1.2, v1.0.0-v1.0.4 
+
+`slsa-verifier` will fail with the following error:
+
+```
+FAILED: SLSA verification failed: could not find a matching valid signature entry: got unexpected errors unable to initialize client, local cache may be corrupt: tuf: invalid key: unable to fetch Rekor public keys from TUF repository
+```
+
+This issue is tracked by [issue #325](https://github.com/slsa-framework/slsa-verifier/issues/325). You *must* update to the newest patch versions of each minor release to fix this issue.
 
 ## Technical design
 

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,14 +1,23 @@
+### [v1.3.2](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.2)
+b1d6c9bbce6274e253f0be33158cacd7fb894c5ebd643f14a911bfe55574f4c0 slsa-verifier-linux-amd64
+
 ### [v1.3.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.1)
 065714d01ba36c81fb11aa7031597a77b08491eb341bac8efc3e452f5d5ed4bd slsa-verifier-linux-amd64
 
 ### [v1.3.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.0)
 1326430d044e8a9522c51e5f721e237b5f75acb6b4e518d129f669403cf7a79a slsa-verifier-linux-amd64
 
+### [v1.2.2](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.2)
+18f49bffa97b8b4e241cc6a5f04a2edfb32d11a4162928ffa255ce6a59699630 slsa-verifier-linux-amd64
+
 ### [v1.2.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.1)
 edd1d430429fa3dfaf249d7ec805891a4b7332ea1d17d23f9d20bc6f4aeebe04 slsa-verifier-linux-amd64
 
 ### [v1.2.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.0)
 37db23392c7918bb4e243cdb097ed5f9d14b9b965dc1905b25bc2d1c0c91bf3d slsa-verifier-linux-amd64
+
+### [v1.1.3](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.3)
+fac369a43cc118525a2b12476f39d10c430e7183fcb70351e800686c33583f6e slsa-verifier-linux-amd64
 
 ### [v1.1.2](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.2)
 2c9225603186f227d01c12bf8b8815f42eb3d4e2a2de7945dd65e704de254d74 slsa-verifier-linux-amd64
@@ -18,6 +27,9 @@ f92fc4e571949c796d7709bb3f0814a733124b0155e484fad095b5ca68b4cb21 slsa-verifier-l
 
 ### [v1.1.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.0)
 14360688de2d294e9cda7b9074ab7dcf02d5c38f2874f6c95d4ad46e300c3e53 slsa-verifier-linux-amd64
+
+### [v1.0.5](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.5)
+b889a9d34237a0c7d64096bf4af4c200c081cc9bc3b0c60585eac9c4dd5d6d10 slsa-verifier-linux-amd64
 
 ### [v1.0.4](https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.4)
 49727307d44c408610316541795ffa501ea21b78061de4589ca88194c522a651 slsa-verifier-linux-amd64


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>


To verify these hashes, do the following for https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.2, https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.2.2, https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.1.3, https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.0.5

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v1.3.2 (or the other)
2. Clone the slsa-verifier repo, compile and verify the provenance:
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$  go run ./cli/slsa-verifier verify-artifact ~/Downloads/slsa-verifier-linux-amd64 --provenance-path ~/Downloads/slsa-verifier-linux-amd64.intoto.jsonl --source-uri github.com/slsa-framework/slsa-verifier --source-tag v1.3.2 --source-branch release/v1.3
```
3. Get the hash.
Either:
```
cat slsa-verifier-linux-amd64.intoto.jsonl | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256'
```
or

```
sha256sum slsa-verifier-linux-amd64
```