### PR TITLE
fix: fix error logs

### DIFF
--- a/verifiers/internal/gha/rekor.go
+++ b/verifiers/internal/gha/rekor.go
@@ -83,13 +83,13 @@ func verifyTlogEntry(ctx context.Context, rekorClient *client.Rekor, e models.Lo
 
 	verifier, err := signature.LoadECDSAVerifier(pubs[*e.LogID].PubKey, crypto.SHA256)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", err, "unable to fetch Rekor public keys from TUF repository")
+		return nil, fmt.Errorf("%w: %s", err, "unable to load a ECDSA verifier")
 	}
 
 	// This function verifies the inclusion proof, the signature on the root hash of the
 	// inclusion proof, and the SignedEntryTimestamp.
 	if err := rverify.VerifyLogEntry(ctx, &e, verifier); err != nil {
-		return nil, fmt.Errorf("%w: %s", err, "unable to fetch Rekor public keys from TUF repository")
+		return nil, fmt.Errorf("%w: %s", err, "unable to verify a log entry")
 	}
 
 	return &e, nil


### PR DESCRIPTION
Fix error logs.

I guess these codes are copied from the just before error handling mistakenly.

https://github.com/slsa-framework/slsa-verifier/blob/137528a257f4533d7445ec6ae1bc57011784dab0/verifiers/internal/gha/rekor.go#L81