### PR TITLE
fix: fix the Go package version to v2

### DIFF
--- a/cli/experimental/service/main.go
+++ b/cli/experimental/service/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/slsa-framework/slsa-verifier/experimental/rest"
+	"github.com/slsa-framework/slsa-verifier/v2/experimental/rest"
 )
 
 func main() {

--- a/cli/slsa-verifier/main_test.go
+++ b/cli/slsa-verifier/main_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/sigstore/cosign/pkg/oci"
 	"github.com/sigstore/cosign/pkg/oci/layout"
 
-	"github.com/slsa-framework/slsa-verifier/cli/slsa-verifier/verify"
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils/container"
+	"github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier/verify"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils/container"
 )
 
 func errCmp(e1, e2 error) bool {
@@ -475,7 +475,7 @@ func Test_runVerifyGHAArtifactPath(t *testing.T) {
 		{
 			name:       "regression: sharded uuids",
 			artifact:   "binary-linux-amd64-sharded",
-			source:     "github.com/slsa-framework/slsa-verifier",
+			source:     "github.com/slsa-framework/slsa-verifier/v2",
 			pbranch:    pString("release/v1.0"),
 			pBuilderID: pString("https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml"),
 			noversion:  true,

--- a/cli/slsa-verifier/main_test.go
+++ b/cli/slsa-verifier/main_test.go
@@ -475,7 +475,7 @@ func Test_runVerifyGHAArtifactPath(t *testing.T) {
 		{
 			name:       "regression: sharded uuids",
 			artifact:   "binary-linux-amd64-sharded",
-			source:     "github.com/slsa-framework/slsa-verifier/v2",
+			source:     "github.com/slsa-framework/slsa-verifier",
 			pbranch:    pString("release/v1.0"),
 			pBuilderID: pString("https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml"),
 			noversion:  true,

--- a/cli/slsa-verifier/verify.go
+++ b/cli/slsa-verifier/verify.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/slsa-framework/slsa-verifier/cli/slsa-verifier/verify"
+	"github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier/verify"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/slsa-verifier/verify/options.go
+++ b/cli/slsa-verifier/verify/options.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/slsa-verifier/verify/verify_artifact.go
+++ b/cli/slsa-verifier/verify/verify_artifact.go
@@ -22,9 +22,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/verifiers"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
 )
 
 // Note: nil branch, tag, version-tag and builder-id means we ignore them during verification.

--- a/cli/slsa-verifier/verify/verify_image.go
+++ b/cli/slsa-verifier/verify/verify_image.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/verifiers"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils/container"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils/container"
 )
 
 type ComputeDigestFn func(string) (string, error)

--- a/experimental/rest/service.go
+++ b/experimental/rest/service.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/verifiers"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers"
 )
 
 var errInvalid = errors.New("invalid")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/slsa-framework/slsa-verifier
+module github.com/slsa-framework/slsa-verifier/v2
 
 go 1.18
 

--- a/register/register.go
+++ b/register/register.go
@@ -3,8 +3,8 @@ package register
 import (
 	"context"
 
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
 )
 
 var SLSAVerifiers = make(map[string]SLSAVerifier)

--- a/verifiers/internal/gcb/keys/keys.go
+++ b/verifiers/internal/gcb/keys/keys.go
@@ -9,7 +9,7 @@ import (
 	"io/fs"
 	"path"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
 //go:embed materials/*

--- a/verifiers/internal/gcb/provenance.go
+++ b/verifiers/internal/gcb/provenance.go
@@ -15,10 +15,10 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	dsselib "github.com/secure-systems-lab/go-securesystemslib/dsse"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/verifiers/internal/gcb/keys"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/internal/gcb/keys"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
 )
 
 var GCBBuilderIDs = []string{

--- a/verifiers/internal/gcb/provenance_test.go
+++ b/verifiers/internal/gcb/provenance_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
 )
 
 // This function sets the statement of the proveannce, as if

--- a/verifiers/internal/gcb/verifier.go
+++ b/verifiers/internal/gcb/verifier.go
@@ -3,11 +3,11 @@ package gcb
 import (
 	"context"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/options"
-	register "github.com/slsa-framework/slsa-verifier/register"
-	_ "github.com/slsa-framework/slsa-verifier/verifiers/internal/gcb/keys"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	register "github.com/slsa-framework/slsa-verifier/v2/register"
+	_ "github.com/slsa-framework/slsa-verifier/v2/verifiers/internal/gcb/keys"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
 )
 
 const VerifierName = "GCB"

--- a/verifiers/internal/gha/builder.go
+++ b/verifiers/internal/gha/builder.go
@@ -8,9 +8,9 @@ import (
 
 	"golang.org/x/mod/semver"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
 )
 
 var (

--- a/verifiers/internal/gha/builder_test.go
+++ b/verifiers/internal/gha/builder_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/options"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
 )
 
 func Test_VerifyWorkflowIdentity(t *testing.T) {

--- a/verifiers/internal/gha/provenance.go
+++ b/verifiers/internal/gha/provenance.go
@@ -17,8 +17,8 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/models"
 
 	"github.com/slsa-framework/slsa-github-generator/signing/envelope"
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/options"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
 )
 
 // SignedAttestation contains a signed DSSE envelope

--- a/verifiers/internal/gha/provenance_test.go
+++ b/verifiers/internal/gha/provenance_test.go
@@ -9,7 +9,7 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
 func provenanceFromBytes(payload []byte) (*intoto.ProvenanceStatement, error) {

--- a/verifiers/internal/gha/rekor.go
+++ b/verifiers/internal/gha/rekor.go
@@ -31,7 +31,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
 	"github.com/slsa-framework/slsa-github-generator/signing/envelope"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
 const (

--- a/verifiers/internal/gha/rekor_test.go
+++ b/verifiers/internal/gha/rekor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/client/index"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
 type searchResult struct {

--- a/verifiers/internal/gha/verifier.go
+++ b/verifiers/internal/gha/verifier.go
@@ -13,11 +13,11 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/rekor/pkg/client"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/register"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils/container"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/register"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils/container"
 )
 
 const VerifierName = "GHA"

--- a/verifiers/utils/builder.go
+++ b/verifiers/utils/builder.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
 type TrustedBuilderID struct {

--- a/verifiers/utils/builder_test.go
+++ b/verifiers/utils/builder_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
 func Test_ParseBuilderID(t *testing.T) {

--- a/verifiers/utils/container/container.go
+++ b/verifiers/utils/container/container.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	crname "github.com/google/go-containerregistry/pkg/name"
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
 func GetImageDigest(image string) (string, error) {

--- a/verifiers/verifier.go
+++ b/verifiers/verifier.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	serrors "github.com/slsa-framework/slsa-verifier/errors"
-	"github.com/slsa-framework/slsa-verifier/options"
-	"github.com/slsa-framework/slsa-verifier/register"
-	_ "github.com/slsa-framework/slsa-verifier/verifiers/internal/gcb"
-	"github.com/slsa-framework/slsa-verifier/verifiers/internal/gha"
-	"github.com/slsa-framework/slsa-verifier/verifiers/utils"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+	"github.com/slsa-framework/slsa-verifier/v2/options"
+	"github.com/slsa-framework/slsa-verifier/v2/register"
+	_ "github.com/slsa-framework/slsa-verifier/v2/verifiers/internal/gcb"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/internal/gha"
+	"github.com/slsa-framework/slsa-verifier/v2/verifiers/utils"
 )
 
 func getVerifier(builderOpts *options.BuilderOpts) (register.SLSAVerifier, error) {


### PR DESCRIPTION
Fix the package name `github.com/slsa-framework/slsa-verifier` to `github.com/slsa-framework/slsa-verifier/v2`.

```sh
git ls-files | grep ".go$" | xargs -n 1 gsed -i "s|github.com/slsa-framework/slsa-verifier|github.com/slsa-framework/slsa-verifier/v2|g"
```

slsa-verifier v2 has been released. https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.0.0

Currently, we can't install slsa-verifier v2 by `go install`.

1. Failed to install v2.

```console
$ go install github.com/slsa-framework/slsa-verifier/cli/slsa-verifier@v2.0.0
go: github.com/slsa-framework/slsa-verifier/cli/slsa-verifier@v2.0.0: github.com/slsa-framework/slsa-verifier@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/slsa-framework/slsa-verifier/v2")
```

2. Installed not v2 but v1.4.1.

```console
$ go install github.com/slsa-framework/slsa-verifier/cli/slsa-verifier@latest
go: downloading github.com/slsa-framework/slsa-verifier v1.4.1
go: downloading github.com/sigstore/cosign v1.12.0
go: downloading github.com/google/trillian v1.4.2
go: downloading github.com/sigstore/rekor v0.11.0
go: downloading github.com/sigstore/sigstore v1.4.2
go: downloading golang.org/x/crypto v0.0.0-20220919173607-35f4265a4bc0
go: downloading github.com/theupdateframework/go-tuf v0.5.1-0.20220920170306-f237d7ca5b42
go: downloading golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
go: downloading github.com/letsencrypt/boulder v0.0.0-20220723181115-27de4befb95e
go: downloading golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
go: downloading google.golang.org/genproto v0.0.0-20220805133916-01dd62135a58
go: downloading github.com/klauspost/compress v1.15.9
go: downloading github.com/aws/aws-sdk-go-v2/config v1.17.7
go: downloading github.com/Azure/go-autorest/autorest/adal v0.9.20
go: downloading golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.12.20
go: downloading github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.5
```