### PR TITLE
docs: fix go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You have two options to install the verifier.
 #### Option 1: Install via go
 
 ```
-$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.0.0
+$ go install github.com/slsa-framework/slsa-verifier/cli/slsa-verifier@v1.3.2
 $ slsa-verifier <options>
 ```
 


### PR DESCRIPTION
https://github.com/slsa-framework/slsa-verifier/pull/375#discussion_r1037775148

I found this doesn't work.
To install slsa-verifier v2 by go install, we have to release v2.0.1 or later.

```console
$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.0.0
go: github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.0.0: github.com/slsa-framework/slsa-verifier@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/slsa-framework/slsa-verifier/v2")
```

So I revert this change.

When we'll release v2.0.1, we would be able to install slsa-verifier v2 by go install.

```console
$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.0.1
```

Signed-off-by: Shunsuke Suzuki <suzuki.shunsuke.1989@gmail.com>