### PR TITLE
feat: allow version to be empty for Installer tests

### DIFF
--- a/.github/workflows/schedule.installer.yml
+++ b/.github/workflows/schedule.installer.yml
@@ -8,7 +8,7 @@ on:
       version:
         type: string
         description: The version to to test for pre-release.
-        required: true
+        required: false
 
 permissions: read-all
 


### PR DESCRIPTION
Signed-off-by: laurentsimon <64505099+laurentsimon@users.noreply.github.com>

This allows us to run the workflow manually to test a list of versions.