### PR TITLE
feat: Enhance help message

### DIFF
--- a/cli/slsa-verifier/verify.go
+++ b/cli/slsa-verifier/verify.go
@@ -32,7 +32,7 @@ func verifyArtifactCmd() *cobra.Command {
 	o := &verify.VerifyOptions{}
 
 	cmd := &cobra.Command{
-		Use: "verify-artifact",
+		Use: "verify-artifact [flags] artifact",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("expects a single path to an artifact")
@@ -79,7 +79,7 @@ func verifyImageCmd() *cobra.Command {
 	o := &verify.VerifyOptions{}
 
 	cmd := &cobra.Command{
-		Use: "verify-image",
+		Use: "verify-image [flags] image",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("expects a single path to an image")


### PR DESCRIPTION
One part that is missing in the output if invocation is wrong is that there is no indication that user has to pass path to a file (artifact/image).

The remaining potential errors from #173 are handled via #231.

Found while looking at #174.

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>