### PR TITLE
fix: Use `Run` instead of `RunE` to handle usage/errors

### DIFF
--- a/cli/slsa-verifier/verify.go
+++ b/cli/slsa-verifier/verify.go
@@ -79,7 +79,7 @@ func verifyImageCmd() *cobra.Command {
 			return nil
 		},
 		Short: "Verifies SLSA provenance on a container image",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			v := verify.VerifyImageCommand{
 				SourceURI:           o.SourceURI,
 				PrintProvenance:     o.PrintProvenance,
@@ -103,11 +103,9 @@ func verifyImageCmd() *cobra.Command {
 
 			if _, err := v.Exec(cmd.Context(), args); err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %v\n", FAILURE, err)
-				return err
+			} else {
+				fmt.Fprintf(os.Stderr, "%s\n", SUCCESS)
 			}
-
-			fmt.Fprintf(os.Stderr, "%s\n", SUCCESS)
-			return nil
 		},
 	}
 

--- a/cli/slsa-verifier/verify.go
+++ b/cli/slsa-verifier/verify.go
@@ -34,7 +34,7 @@ func verifyArtifactCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify-artifact [flags] artifact [artifact..]",
 		Short: "Verifies SLSA provenance on artifact blobs given as arguments (assuming same provenance)",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run:  func(cmd *cobra.Command, args []string) {
 			v := verify.VerifyArtifactCommand{
 				ProvenancePath:      o.ProvenancePath,
 				SourceURI:           o.SourceURI,
@@ -56,11 +56,9 @@ func verifyArtifactCmd() *cobra.Command {
 
 			if _, err := v.Exec(cmd.Context(), args); err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %v\n", FAILURE, err)
-				return err
+			} else {
+				fmt.Fprintf(os.Stderr, "%s\n", SUCCESS)
 			}
-
-			fmt.Fprintf(os.Stderr, "%s\n", SUCCESS)
-			return nil
 		},
 	}
 

--- a/cli/slsa-verifier/verify.go
+++ b/cli/slsa-verifier/verify.go
@@ -34,7 +34,7 @@ func verifyArtifactCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify-artifact [flags] artifact [artifact..]",
 		Short: "Verifies SLSA provenance on artifact blobs given as arguments (assuming same provenance)",
-		Run:  func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, args []string) {
 			v := verify.VerifyArtifactCommand{
 				ProvenancePath:      o.ProvenancePath,
 				SourceURI:           o.SourceURI,


### PR DESCRIPTION
We want to only display the usage message if there is an error in the parsing of arguments. Once the arguments are parsed and we invoke the internal implementation the usage message should not be displayed anymore, regardless of what internal error gets returned. Fortunately, the fix is easy.

Tested:

* passing scenario:
```
[...]$ slsa-verifier verify-artifact \
       --provenance-path multiple.intoto.jsonl \
       --source-uri github.com/example/repo fib
Verified signature against tlog entry index 9712459 at URL: ...
Verified build using builder ...
Verifying artifact fib: PASSED

PASSED: Verified SLSA provenance
```

* failing scenario with missing artifact file:
```
[...]$ slsa-verifier verify-artifact \
       --provenance-path multiple.intoto.jsonl \
       --source-uri github.com/example/repo fibs
Verifying artifact fibs: FAILED: open fibs: no such file or directory

FAILED: SLSA verification failed: open fibs: no such file or directory
```

* failing scenario with invalid artifact:
```
[...]$ slsa-verifier verify-artifact \
       --provenance-path multiple.intoto.jsonl \
       --source-uri github.com/example/repo multiple.intoto.jsonl
Verified signature against tlog entry index 9712459 at URL: ...
Verifying artifact multiple.intoto.jsonl: FAILED: expected hash ...

FAILED: SLSA verification failed: expected hash ...
```

* failing scenario due to invalid usage (missing required arguments):
```
[...]$ slsa-verifier verify-artifact \
       --provenance-path multiple.intoto.jsonl
Usage:
  slsa-verifier verify-artifact [flags] artifact [artifact..]

Flags:
      --build-workflow-input map[]    [optional] a workflow input provided by a user at trigger time in the format 'key=value'. (Only for 'workflow_dispatch' events on GitHub Actions). (default map[])
      --builder-id string             [optional] the unique builder ID who created the provenance
  -h, --help                          help for verify-artifact
      --print-provenance              [optional] print the verified provenance to stdout
      --provenance-path string        path to a provenance file
      --source-branch string          [optional] expected branch the binary was compiled from
      --source-tag string             [optional] expected tag the binary was compiled from
      --source-uri string             expected source repository that should have produced the binary, e.g. github.com/some/repo
      --source-versioned-tag string   [optional] expected version the binary was compiled from. Uses semantic version to match the tag

required flag(s) "source-uri" not set
exit status 1
```

Fixes #307

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>