### PR TITLE
fix: fix exit status on command execution errors

### DIFF
--- a/cli/slsa-verifier/verify.go
+++ b/cli/slsa-verifier/verify.go
@@ -62,6 +62,7 @@ func verifyArtifactCmd() *cobra.Command {
 
 			if _, err := v.Exec(cmd.Context(), args); err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %v\n", FAILURE, err)
+				os.Exit(1)
 			} else {
 				fmt.Fprintf(os.Stderr, "%s\n", SUCCESS)
 			}
@@ -109,6 +110,7 @@ func verifyImageCmd() *cobra.Command {
 
 			if _, err := v.Exec(cmd.Context(), args); err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %v\n", FAILURE, err)
+				os.Exit(1)
 			} else {
 				fmt.Fprintf(os.Stderr, "%s\n", SUCCESS)
 			}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes e2e tests, for e.g. https://github.com/slsa-framework/slsa-github-generator/issues/1445

The error showed that the exit code for failing verification was 0. This was a small regression from PR https://github.com/slsa-framework/slsa-verifier/pull/424 that changed RunE to Run, and so the exit status was removed.