### PR TITLE
test: add builder id tests for short form

### DIFF
--- a/cli/slsa-verifier/main_regression_test.go
+++ b/cli/slsa-verifier/main_regression_test.go
@@ -584,7 +584,7 @@ func Test_runVerifyGHAArtifactPath(t *testing.T) {
 				// before GA. Add the tests for tag verification.
 				if version != "" && semver.Compare(version, "v1.0.0") > 0 {
 					builderIDs = append(builderIDs, []*string{
-						// pString(builder + "@" + sv),
+						pString(builder + "@" + sv),
 						pString(builder + "@refs/tags/" + sv),
 					}...)
 				}
@@ -605,6 +605,8 @@ func Test_runVerifyGHAArtifactPath(t *testing.T) {
 						BuildWorkflowInputs: tt.inputs,
 					}
 
+					// The outBuilderID is the actual builder ID from the provenance.
+					// This is always long form for the GHA builders.
 					outBuilderID, err := cmd.Exec(context.Background(), artifacts)
 					if !errCmp(err, tt.err) {
 						t.Errorf("%v: %v", v, cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
@@ -619,15 +621,6 @@ func Test_runVerifyGHAArtifactPath(t *testing.T) {
 						if err := outBuilderID.Matches(tt.outBuilderID, false); err != nil {
 							t.Errorf(fmt.Sprintf("matches failed (1): %v", err))
 						}
-					}
-
-					if bid == nil {
-						continue
-					}
-
-					// Validate against builderID we generated automatically.
-					if err := outBuilderID.Matches(*bid, false); err != nil {
-						t.Errorf(fmt.Sprintf("matches failed (2): %v", err))
 					}
 
 					// Smoke test against the CLI command
@@ -660,6 +653,18 @@ func Test_runVerifyGHAArtifactPath(t *testing.T) {
 					cliErr := cliCmd.Execute()
 					if !errCmp(cliErr, tt.err) {
 						t.Errorf("%v: %v", v, cmp.Diff(cliErr, tt.err, cmpopts.EquateErrors()))
+					}
+
+					if bid == nil {
+						continue
+					}
+
+					// If we have a generated a user-provided bid, then validate it against the
+					// resulting builderID returned by the provenance check.
+					// Since this a GHA and the certificate ID is in long form,
+					// we pass `allowRef = true`.
+					if err := outBuilderID.Matches(*bid, true); err != nil {
+						t.Errorf(fmt.Sprintf("matches failed (2): %v", err))
 					}
 				}
 			}
@@ -810,7 +815,7 @@ func Test_runVerifyGHAArtifactImage(t *testing.T) {
 				//	3. With only the name of the builder.
 				//	4. With no builder ID.
 				builderIDs := []*string{
-					// pString(builder + "@" + sv),
+					pString(builder + "@" + sv),
 					pString(builder + "@refs/tags/" + sv),
 					pString(builder),
 					nil,
@@ -850,8 +855,12 @@ func Test_runVerifyGHAArtifactImage(t *testing.T) {
 					if bid == nil {
 						return
 					}
-					// Validate against builderID we generated automatically.
-					if err := outBuilderID.Matches(*bid, false); err != nil {
+
+					// If we have a generated a user-provided bid, then validate it against the
+					// resulting builderID returned by the provenance check.
+					// Since this a GHA and the certificate ID is in long form,
+					// we pass `allowRef = true`.
+					if err := outBuilderID.Matches(*bid, true); err != nil {
 						t.Errorf(fmt.Sprintf("matches failed: %v", err))
 					}
 				}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/slsa-framework/slsa-verifier/issues/440

This adds back in the commented out tests for testing the short form of the builder ID for GHA artifacts and images `builder@TAG`. The tests were failing because they set `allowRef = false`, but for GHA, the builder identity returned is always in long form, meaning that we have to allow the short form matches in the test (which is also done in the code path: https://github.com/slsa-framework/slsa-verifier/blob/5eea7c55379c777df48a3e5a95cedea44169f6c1/verifiers/internal/gha/builder.go#L105)

cc @laurentsimon 