### PR TITLE
fix: Update references check

### DIFF
--- a/.github/workflows/pre-submit.actions.yml
+++ b/.github/workflows/pre-submit.actions.yml
@@ -39,24 +39,3 @@ jobs:
         with:
           name: dist
           path: dist/
-
-  check-docs:
-    runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.body, '#label:release') }}
-    env:
-      BODY: ${{ github.event.pull_request.body }}
-    steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-
-      - name: Check documentation is up-to-date
-        run: |
-          RELEASE_TAG=$(
-            echo "$BODY" | \
-            grep -oE '^[[:blank:]]*#label:release[[:blank:]]+v?[0-9]+\.[0-9]+\.[0-9]+' | \
-            sed -E 's/.*([0-9]+\.[0-9]+\.[0-9])/\1/'
-          )
-          if [[ -z "$RELEASE_TAG" ]]; then
-              echo "Invalid release PR body. Must include `#label:release vX.Y.Z"
-              exit 1
-          fi
-          RELEASE_TAG="${RELEASE_TAG}" ./.github/workflows/scripts/pre-release/references.sh

--- a/.github/workflows/pre-submit.references.yml
+++ b/.github/workflows/pre-submit.references.yml
@@ -1,0 +1,29 @@
+name: References pre submits
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: read-all
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.body, '#label:release') }}
+    env:
+      BODY: ${{ github.event.pull_request.body }}
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Check documentation is up-to-date
+        run: |
+          RELEASE_TAG=$(:
+            echo "$BODY" |
+            grep -oE '^[[:blank:]]*#label:release[[:blank:]]+v?[0-9]+\.[0-9]+\.[0-9]+' |
+            sed -E 's/.*([0-9]+\.[0-9]+\.[0-9])/\1/'
+          )
+          if [[ -z "$RELEASE_TAG" ]]; then
+              echo 'Invalid release PR body. Must include `#label:release vX.Y.Z`'
+              exit 1
+          fi
+          RELEASE_TAG="${RELEASE_TAG}" ./.github/workflows/scripts/pre-release/references.sh


### PR DESCRIPTION
Fix printing an error in references check. Previously the echoed string was enclosed in double quotes and had backticks which are evaluated as a command. This change changes the string to use single quotes which are printed statically.

Also moves the references check to its own file that triggers when the PR description is updated. This allows for fixing the PR description after failures, and triggering the check to re-run.

/cc @asraa 