### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ $ go mod tidy
 $ cd tooling
 $ grep _ tooling_test.go | cut -f2 -d '"' | xargs -n1 -t go install
 ``` 
+Alternatively, if your project does not rely on additional tools and only uses slsa-verifier, you can instead run the following commands:
+```bash
+$ cd tooling
+$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier
+``` 
 
 #### Option 2: Compile manually
 


### PR DESCRIPTION
Adding an alternative option for installing slsa-verifier if you do not rely on additional tooling. The benefit of this option is improved readability.