### PR TITLE
feat: npm: Make package name and version mandatory for verification

### DIFF
--- a/cli/slsa-verifier/verify/options.go
+++ b/cli/slsa-verifier/verify/options.go
@@ -118,6 +118,8 @@ func (o *VerifyNpmOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.MarkFlagRequired("source-uri")
 	cmd.MarkFlagRequired("builder-id")
+	cmd.MarkFlagRequired("package-name")
+	cmd.MarkFlagRequired("package-version")
 	cmd.MarkFlagsMutuallyExclusive("source-versioned-tag", "source-tag")
 }
 


### PR DESCRIPTION
closes https://github.com/slsa-framework/slsa-verifier/issues/513

If people complain about the version, we can re-visit. If we make these optional, it will be impossible to remove.