### PR TITLE
feat: Use low-perms delegator for Node.js builder

### DIFF
--- a/verifiers/internal/gha/builder.go
+++ b/verifiers/internal/gha/builder.go
@@ -35,11 +35,11 @@ var defaultContainerTrustedReusableWorkflows = map[string]bool{
 }
 
 var delegatorGenericReusableWorkflow = trustedBuilderRepository + "/.github/workflows/delegator_generic_slsa3.yml"
-var delegatorLowPermsReusableWorkflow = trustedBuilderRepository + "/.github/workflows/delegator_low-perms_slsa3.yml"
+var delegatorLowPermsGenericReusableWorkflow = trustedBuilderRepository + "/.github/workflows/delegator_lowperms-generic_slsa3.yml"
 
 var defaultBYOBReusableWorkflows = map[string]bool{
-	delegatorGenericReusableWorkflow:  true,
-	delegatorLowPermsReusableWorkflow: true,
+	delegatorGenericReusableWorkflow:         true,
+	delegatorLowPermsGenericReusableWorkflow: true,
 }
 
 // VerifyCertficateSourceRepository verifies the source repository.

--- a/verifiers/internal/gha/builder.go
+++ b/verifiers/internal/gha/builder.go
@@ -35,9 +35,11 @@ var defaultContainerTrustedReusableWorkflows = map[string]bool{
 }
 
 var delegatorGenericReusableWorkflow = trustedBuilderRepository + "/.github/workflows/delegator_generic_slsa3.yml"
+var delegatorLowPermsReusableWorkflow = trustedBuilderRepository + "/.github/workflows/delegator_low-perms_slsa3.yml"
 
 var defaultBYOBReusableWorkflows = map[string]bool{
-	delegatorGenericReusableWorkflow: true,
+	delegatorGenericReusableWorkflow:  true,
+	delegatorLowPermsReusableWorkflow: true,
 }
 
 // VerifyCertficateSourceRepository verifies the source repository.

--- a/verifiers/internal/gha/verifier.go
+++ b/verifiers/internal/gha/verifier.go
@@ -101,7 +101,7 @@ func verifyNpmEnvAndCert(env *dsse.Envelope,
 	// We verify against the delegator re-usable workflow, not the user-provided
 	// builder. This is because the signing identity for delegator-based builders
 	// is *always* the delegator workflow.
-	expectedDelegatorWorkflow := httpsGithubCom + delegatorLowPermsReusableWorkflow
+	expectedDelegatorWorkflow := httpsGithubCom + delegatorLowPermsGenericReusableWorkflow
 	delegatorBuilderOpts := options.BuilderOpts{
 		ExpectedID: &expectedDelegatorWorkflow,
 	}

--- a/verifiers/internal/gha/verifier.go
+++ b/verifiers/internal/gha/verifier.go
@@ -101,7 +101,7 @@ func verifyNpmEnvAndCert(env *dsse.Envelope,
 	// We verify against the delegator re-usable workflow, not the user-provided
 	// builder. This is because the signing identity for delegator-based builders
 	// is *always* the delegator workflow.
-	expectedDelegatorWorkflow := httpsGithubCom + delegatorGenericReusableWorkflow
+	expectedDelegatorWorkflow := httpsGithubCom + delegatorLowPermsReusableWorkflow
 	delegatorBuilderOpts := options.BuilderOpts{
 		ExpectedID: &expectedDelegatorWorkflow,
 	}

--- a/verifiers/utils/builder.go
+++ b/verifiers/utils/builder.go
@@ -7,6 +7,7 @@ import (
 	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
+// TrustedBuilderID represents a builder ID that has been explicitly trusted.
 type TrustedBuilderID struct {
 	name, version string
 }
@@ -24,7 +25,7 @@ func TrustedBuilderIDNew(builderID string, needVersion bool) (*TrustedBuilderID,
 	}, nil
 }
 
-// Matches matches the builderID string against the reference builderID.
+// MatchesLoose matches the builderID string against the reference builderID.
 // If the builderID contains a semver, the full builderID must match.
 // Otherwise, only the name needs to match.
 // `allowRef: true` indicates that the matching need not be an eaxct
@@ -39,7 +40,7 @@ func (b *TrustedBuilderID) MatchesLoose(builderID string, allowRef bool) error {
 
 	if name != b.name {
 		return fmt.Errorf("%w: expected name '%s', got '%s'", serrors.ErrorMismatchBuilderID,
-			name, b.name)
+			b.name, name)
 	}
 
 	if version != "" && version != b.version {
@@ -55,7 +56,7 @@ func (b *TrustedBuilderID) MatchesLoose(builderID string, allowRef bool) error {
 	return nil
 }
 
-// Matches matches the builderID string against the reference builderID.
+// MatchesFull matches the builderID string against the reference builderID.
 // Both the name and versions are always verified.
 func (b *TrustedBuilderID) MatchesFull(builderID string, allowRef bool) error {
 	name, version, err := ParseBuilderID(builderID, false)
@@ -65,7 +66,7 @@ func (b *TrustedBuilderID) MatchesFull(builderID string, allowRef bool) error {
 
 	if name != b.name {
 		return fmt.Errorf("%w: expected name '%s', got '%s'", serrors.ErrorMismatchBuilderID,
-			name, b.name)
+			b.name, name)
 	}
 
 	if version != b.version {
@@ -81,14 +82,17 @@ func (b *TrustedBuilderID) MatchesFull(builderID string, allowRef bool) error {
 	return nil
 }
 
+// Name returns the trusted builder's name.
 func (b *TrustedBuilderID) Name() string {
 	return b.name
 }
 
+// Version returns the trusted builder's version reference if any.
 func (b *TrustedBuilderID) Version() string {
 	return b.version
 }
 
+// String returns the full trusted builder ID as a string.
 func (b *TrustedBuilderID) String() string {
 	if b.version == "" {
 		return b.name


### PR DESCRIPTION
Use the low-permissions delegator introduced in https://github.com/slsa-framework/slsa-github-generator/pull/2075 for the Node.js builder.