### PR TITLE
feat: Support different source branch/tag from trigger branch/tag.

### DIFF
--- a/verifiers/internal/gha/provenance.go
+++ b/verifiers/internal/gha/provenance.go
@@ -160,12 +160,12 @@ func sourceFromURI(uri string, allowNoRef bool) (string, error) {
 
 	r := strings.Split(uri, "@")
 	if len(r) < 2 && !allowNoRef {
-		return "", fmt.Errorf("%w: %s", serrors.ErrorMalformedURI,
+		return "", fmt.Errorf("%w: ref required: %s", serrors.ErrorMalformedURI,
 			uri)
 	}
 	if len(r) < 1 {
-		return "", fmt.Errorf("%w: %s", serrors.ErrorMalformedURI,
-			uri)
+		// Split should always return a slice with length > 0
+		panic(fmt.Errorf("%w: %s", serrors.ErrorMalformedURI, uri))
 	}
 
 	return r[0], nil
@@ -277,8 +277,7 @@ func VerifyNpmPackageProvenance(env *dsselib.Envelope, workflow *WorkflowIdentit
 	return nil
 }
 
-func VerifyProvenance(env *dsselib.Envelope, provenanceOpts *options.ProvenanceOpts, byob bool,
-) error {
+func VerifyProvenance(env *dsselib.Envelope, provenanceOpts *options.ProvenanceOpts, byob bool) error {
 	prov, err := slsaprovenance.ProvenanceFromEnvelope(env)
 	if err != nil {
 		return err
@@ -298,7 +297,9 @@ func VerifyProvenance(env *dsselib.Envelope, provenanceOpts *options.ProvenanceO
 		}
 	}
 
-	return VerifyProvenanceCommonOptions(prov, provenanceOpts, false)
+	// NOTE: BYOB workflows may have materials without a ref if a different sha
+	// is specified.
+	return VerifyProvenanceCommonOptions(prov, provenanceOpts, byob)
 }
 
 func VerifyProvenanceCommonOptions(prov slsaprovenance.Provenance, provenanceOpts *options.ProvenanceOpts,

--- a/verifiers/internal/gha/slsaprovenance/v0.2/provenance.go
+++ b/verifiers/internal/gha/slsaprovenance/v0.2/provenance.go
@@ -2,6 +2,7 @@ package v02
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -60,22 +61,33 @@ func (prov *ProvenanceV02) Subjects() ([]intoto.Subject, error) {
 }
 
 func (prov *ProvenanceV02) GetBranch() (string, error) {
-	// GetBranch gets the branch from the invocation parameters.
-	environment, ok := prov.Predicate.Invocation.Environment.(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("%w: %s", serrors.ErrorInvalidDssePayload, "parameters type")
+	// Returns the branch from the source materials.
+	sourceURI, err := prov.SourceURI()
+	if err != nil {
+		return "", err
 	}
 
-	return slsaprovenance.GetBranch(environment, prov.PredicateType)
+	parts := strings.Split(sourceURI, "@")
+	if len(parts) > 1 && strings.HasPrefix(parts[1], "refs/heads") {
+		return parts[1], nil
+	}
+
+	return "", nil
 }
 
 func (prov *ProvenanceV02) GetTag() (string, error) {
-	environment, ok := prov.Predicate.Invocation.Environment.(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("%w: %s", serrors.ErrorInvalidDssePayload, "parameters type")
+	// Returns the tag from the source materials.
+	sourceURI, err := prov.SourceURI()
+	if err != nil {
+		return "", err
 	}
 
-	return slsaprovenance.GetTag(environment, prov.PredicateType)
+	parts := strings.Split(sourceURI, "@")
+	if len(parts) > 1 && strings.HasPrefix(parts[1], "refs/tags") {
+		return parts[1], nil
+	}
+
+	return "", nil
 }
 
 func (prov *ProvenanceV02) GetWorkflowInputs() (map[string]interface{}, error) {
@@ -85,7 +97,7 @@ func (prov *ProvenanceV02) GetWorkflowInputs() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("%w: %s", serrors.ErrorInvalidDssePayload, "parameters type")
 	}
 
-	return slsaprovenance.GetWorkflowInputs(environment, prov.PredicateType)
+	return slsaprovenance.GetWorkflowInputs(environment)
 }
 
 func (prov *ProvenanceV02) GetBuildTriggerPath() (string, error) {


### PR DESCRIPTION
- Updates handling of github environment variables such that they can be uppercase or lowercase.
- Pulls source branch/tag from the dependencies URI (`materials` or `resolvedDependencies`)

This means that `--source-branch` and `--source-tag` will not work if provided because the ref is not included in the source dependency URI if a different sha is provided from the triggering sha.