### PR TITLE
fix: revert to using resolvedDepdendencies for source verification

### DIFF
--- a/verifiers/internal/gha/provenance_test.go
+++ b/verifiers/internal/gha/provenance_test.go
@@ -362,8 +362,8 @@ func Test_verifySourceURI(t *testing.T) {
 						// 		"path":       "some/path",
 						// 	},
 						// },
-						ExternalParameters: map[string]interface{}{
-							"source": slsa1.ResourceDescriptor{
+						ResolvedDependencies: []slsa1.ResourceDescriptor{
+							{
 								URI: tt.provMaterialsURI,
 							},
 						},
@@ -372,7 +372,7 @@ func Test_verifySourceURI(t *testing.T) {
 			}
 
 			if tt.provMaterialsURI == "" {
-				prov1.Predicate.BuildDefinition.ExternalParameters = nil
+				prov1.Predicate.BuildDefinition.ResolvedDependencies = nil
 			}
 			err = verifySourceURI(prov1, tt.expectedSourceURI, tt.allowNoMaterialRef)
 			if !errCmp(err, tt.err) {


### PR DESCRIPTION
Reverts the logic in https://github.com/slsa-framework/slsa-verifier/commit/db0560e3285e082f58a6d718a720047bb302fdd9.

For now, we assume a GHA builder verifier contract to detect the source in the first resolvedDependency. Per SLSA discussions, we will likely resolve this with some metadata in the name or annotations to distinguish the dependencies.

* fix: Use the first resolvedDependencies for SLSA v1.0 source verification