### PR TITLE
fix: only allow hashes of 256 bits or more

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -40,5 +40,6 @@ var (
 	ErrorRekorPubKey               = errors.New("error retrieving Rekor public keys")
 	ErrorInvalidPackageName        = errors.New("invalid package name")
 	ErrorInvalidSubject            = errors.New("invalid subject")
+	ErrorInvalidHash               = errors.New("invalid hash")
 	ErrorNotPresent                = errors.New("not present")
 )

--- a/verifiers/internal/gha/provenance.go
+++ b/verifiers/internal/gha/provenance.go
@@ -181,10 +181,8 @@ func verifyDigest(prov slsaprovenance.Provenance, expectedHash string) error {
 	// 8 bit represented in hex, so 8/2=4.
 	bitLength := len(expectedHash) * 4
 	expectedAlgo := fmt.Sprintf("sha%v", bitLength)
-	// TODO(#630): Add subject digest minimum bit length check.
-	// sha1 is 160 bit (FWIW).
-	if bitLength == 160 {
-		expectedAlgo = "sha1"
+	if bitLength < 256 {
+		return fmt.Errorf("%w: hash must be at least 256-bit long. Got %d", serrors.ErrorInvalidHash, bitLength)
 	}
 
 	for _, subject := range subjects {

--- a/verifiers/internal/gha/provenance.go
+++ b/verifiers/internal/gha/provenance.go
@@ -182,7 +182,7 @@ func verifyDigest(prov slsaprovenance.Provenance, expectedHash string) error {
 	bitLength := len(expectedHash) * 4
 	expectedAlgo := fmt.Sprintf("sha%v", bitLength)
 	if bitLength < 256 {
-		return fmt.Errorf("%w: hash must be at least 256-bit long. Got %d", serrors.ErrorInvalidHash, bitLength)
+		return fmt.Errorf("%w: expected minimum 256-bit. Got %d", serrors.ErrorInvalidHash, bitLength)
 	}
 
 	for _, subject := range subjects {

--- a/verifiers/internal/gha/provenance_test.go
+++ b/verifiers/internal/gha/provenance_test.go
@@ -100,6 +100,21 @@ func Test_VerifyDigest(t *testing.T) {
 		expected     error
 	}{
 		{
+			name: "invalid short hash",
+			prov: &testProvenance{
+				subjects: []intoto.Subject{
+					{
+						Digest: common.DigestSet{
+							"sha1": "4506290e2e8feb1f34b27a044f7cc863c830ef6b",
+						},
+					},
+				},
+			},
+			// NOTE: the hash is one character short of sha256 hash.
+			artifactHash: "0ae7e4fa71686538440012ee36a2634dbaa19df2dd16a466f52411fb348bbc4",
+			expected:     serrors.ErrorInvalidHash,
+		},
+		{
 			name: "invalid dsse: no sha256 subject digest",
 			prov: &testProvenance{
 				subjects: []intoto.Subject{


### PR DESCRIPTION
closes https://github.com/slsa-framework/slsa-verifier/issues/630