### PR TITLE
refactor: Add more git utils

### DIFF
--- a/verifiers/internal/gha/provenance_test.go
+++ b/verifiers/internal/gha/provenance_test.go
@@ -264,6 +264,13 @@ func Test_verifySourceURI(t *testing.T) {
 			err:               serrors.ErrorMalformedURI,
 		},
 		{
+			name:              "not github repo",
+			provTriggerURI:    "git+https://notgithub.com/some/repo@v1.2.3",
+			provMaterialsURI:  "git+https://notgithub.com/some/repo@v1.2.3",
+			expectedSourceURI: "git+https://notgithub.com/some/repo",
+			err:               serrors.ErrorMalformedURI,
+		},
+		{
 			name:              "match source",
 			provTriggerURI:    "git+https://github.com/some/repo@v1.2.3",
 			provMaterialsURI:  "git+https://github.com/some/repo@v1.2.3",

--- a/verifiers/utils/git.go
+++ b/verifiers/utils/git.go
@@ -7,16 +7,51 @@ import (
 	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
 )
 
-// ParseGitRef validates that the given git ref is a valid ref of the given type and returns its name.
-func ParseGitRef(refType, ref string) (string, error) {
-	refPrefix := fmt.Sprintf("refs/%s/", refType)
-	if !strings.HasPrefix(ref, refPrefix) {
-		return "", fmt.Errorf("%w: %s: not of the form '%s<name>'", serrors.ErrorInvalidRef, ref, refPrefix)
+// NormalizeGitURI normalizes a git URI to include a git+https:// prefix.
+func NormalizeGitURI(s string) string {
+	if !strings.HasPrefix(s, "git+") {
+		if !strings.Contains(s, "://") {
+			return "git+https://" + s
+		}
+		return "git+" + s
+	}
+	return s
+}
+
+// ParseGitURIAndRef retrieves the URI and ref from the given URI.
+func ParseGitURIAndRef(uri string) (string, string, error) {
+	if uri == "" {
+		return "", "", fmt.Errorf("%w: empty uri", serrors.ErrorMalformedURI)
+	}
+	if !strings.HasPrefix(uri, "git+") {
+		return "", "", fmt.Errorf("%w: not a git URI: %q", serrors.ErrorMalformedURI, uri)
 	}
 
-	name := strings.TrimPrefix(ref, refPrefix)
-	if strings.TrimSpace(name) == "" {
-		return "", fmt.Errorf("%w: %s: not of the form '%s<name>'", serrors.ErrorInvalidRef, ref, refPrefix)
+	r := strings.SplitN(uri, "@", 2)
+	if len(r) < 2 {
+		return r[0], "", nil
+	}
+
+	return r[0], r[1], nil
+}
+
+// ParseGitRef parses the git ref and returns its type and name.
+func ParseGitRef(ref string) (string, string) {
+	parts := strings.SplitN(ref, "/", 3)
+	if len(parts) < 3 || parts[0] != "refs" {
+		return "", ref
+	}
+	return parts[1], parts[2]
+}
+
+// ValidateGitRef validates that the given git ref is a valid ref of the given type and returns its name.
+func ValidateGitRef(refType, ref string) (string, error) {
+	typ, name := ParseGitRef(ref)
+	if typ != refType {
+		return "", fmt.Errorf("%w: %q: unexpected ref type: %q", serrors.ErrorInvalidRef, ref, typ)
+	}
+	if name == "" {
+		return "", fmt.Errorf("%w: %q: empty ref name", serrors.ErrorInvalidRef, ref)
 	}
 
 	return name, nil
@@ -24,10 +59,10 @@ func ParseGitRef(refType, ref string) (string, error) {
 
 // TagFromGitRef returns the tagname from a tag ref.
 func TagFromGitRef(ref string) (string, error) {
-	return ParseGitRef("tags", ref)
+	return ValidateGitRef("tags", ref)
 }
 
 // BranchFromGitRef returns the tagname from a tag ref.
 func BranchFromGitRef(ref string) (string, error) {
-	return ParseGitRef("heads", ref)
+	return ValidateGitRef("heads", ref)
 }

--- a/verifiers/utils/git_test.go
+++ b/verifiers/utils/git_test.go
@@ -1,0 +1,269 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	serrors "github.com/slsa-framework/slsa-verifier/v2/errors"
+)
+
+func Test_NormalizeGitURI(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		uri      string
+		expected string
+	}{
+		{
+			name:     "empty uri",
+			uri:      "",
+			expected: "git+https://",
+		},
+		{
+			name:     "https scheme",
+			uri:      "https://github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+			expected: "git+https://github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+		},
+		{
+			name:     "http scheme",
+			uri:      "http://github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+			expected: "git+http://github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+		},
+		{
+			name:     "git+https scheme",
+			uri:      "git+https://github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+			expected: "git+https://github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+		},
+		{
+			name:     "no scheme",
+			uri:      "github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+			expected: "git+https://github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+		},
+		{
+			name:     "git+ scheme",
+			uri:      "git+github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+			expected: "git+github.com/kubernetes/kubernetes@refs/tags/v1.0.0",
+		},
+		{
+			name:     "https scheme no ref",
+			uri:      "https://github.com/kubernetes/kubernetes",
+			expected: "git+https://github.com/kubernetes/kubernetes",
+		},
+		{
+			name:     "http scheme no ref",
+			uri:      "http://github.com/kubernetes/kubernetes",
+			expected: "git+http://github.com/kubernetes/kubernetes",
+		},
+		{
+			name:     "git+https scheme no ref",
+			uri:      "git+https://github.com/kubernetes/kubernetes",
+			expected: "git+https://github.com/kubernetes/kubernetes",
+		},
+		{
+			name:     "no scheme no ref",
+			uri:      "github.com/kubernetes/kubernetes",
+			expected: "git+https://github.com/kubernetes/kubernetes",
+		},
+		{
+			name:     "git+ scheme no ref",
+			uri:      "git+github.com/kubernetes/kubernetes",
+			expected: "git+github.com/kubernetes/kubernetes",
+		},
+	}
+
+	for i := range testCases {
+		tt := testCases[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := NormalizeGitURI(tt.uri), tt.expected; got != want {
+				t.Errorf("unexpected value, got: %q, want: %q", got, want)
+			}
+		})
+	}
+}
+
+func Test_ParseGitURIAndRef(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		uri         string
+		expectedURI string
+		expectedRef string
+		err         error
+	}{
+		{
+			name: "empty uri",
+			uri:  "",
+			err:  serrors.ErrorMalformedURI,
+		},
+		{
+			name: "no scheme with ref",
+			uri:  "github.com/kubernetes/kubernetes@v1.0.0",
+			err:  serrors.ErrorMalformedURI,
+		},
+		{
+			name: "https scheme with ref",
+			uri:  "https://github.com/kubernetes/kubernetes@v1.0.0",
+			err:  serrors.ErrorMalformedURI,
+		},
+		{
+			name:        "git+https scheme with ref",
+			uri:         "git+https://github.com/kubernetes/kubernetes@v1.0.0",
+			expectedURI: "git+https://github.com/kubernetes/kubernetes",
+			expectedRef: "v1.0.0",
+		},
+	}
+
+	for i := range testCases {
+		tt := testCases[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uri, ref, err := ParseGitURIAndRef(tt.uri)
+			if diff := cmp.Diff(tt.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if want, got := tt.expectedURI, uri; got != want {
+				t.Fatalf("unexpected uri, got: %q, want: %q", got, want)
+			}
+
+			if want, got := tt.expectedRef, ref; got != want {
+				t.Fatalf("unexpected ref, got: %q, want: %q", got, want)
+			}
+		})
+	}
+}
+
+func Test_ParseGitRef(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		ref          string
+		expectedType string
+		expectedRef  string
+	}{
+		{
+			name:         "empty ref",
+			ref:          "",
+			expectedType: "",
+			expectedRef:  "",
+		},
+		{
+			name:         "no type ",
+			ref:          "v1.0.0",
+			expectedType: "",
+			expectedRef:  "v1.0.0",
+		},
+		{
+			name:         "no type with slash",
+			ref:          "tags/v1.0.0",
+			expectedType: "",
+			expectedRef:  "tags/v1.0.0",
+		},
+		{
+			name:         "type without slash",
+			ref:          "refs/mytype/v1.0.0",
+			expectedType: "mytype",
+			expectedRef:  "v1.0.0",
+		},
+		{
+			name:         "type with slash",
+			ref:          "refs/mytype/feat/v1.0.0",
+			expectedType: "mytype",
+			expectedRef:  "feat/v1.0.0",
+		},
+	}
+
+	for i := range testCases {
+		tt := testCases[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			typ, ref := ParseGitRef(tt.ref)
+			if want, got := tt.expectedType, typ; got != want {
+				t.Fatalf("unexpected type, got: %q, want: %q", got, want)
+			}
+
+			if want, got := tt.expectedRef, ref; got != want {
+				t.Fatalf("unexpected ref, got: %q, want: %q", got, want)
+			}
+		})
+	}
+}
+
+func Test_ValidateGitRef(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		ref         string
+		typ         string
+		expectedRef string
+		err         error
+	}{
+		{
+			name: "empty ref",
+			ref:  "",
+			typ:  "",
+			err:  serrors.ErrorInvalidRef,
+		},
+		{
+			name:        "no type ",
+			ref:         "v1.0.0",
+			typ:         "",
+			expectedRef: "v1.0.0",
+		},
+		{
+			name:        "no type with slash",
+			ref:         "tags/v1.0.0",
+			typ:         "",
+			expectedRef: "tags/v1.0.0",
+		},
+		{
+			name:        "type without slash",
+			ref:         "refs/mytype/v1.0.0",
+			typ:         "mytype",
+			expectedRef: "v1.0.0",
+		},
+		{
+			name: "mismatch type",
+			ref:  "refs/mytype/v1.0.0",
+			typ:  "tags",
+			err:  serrors.ErrorInvalidRef,
+		},
+		{
+			name:        "type with slash",
+			ref:         "refs/mytype/feat/v1.0.0",
+			typ:         "mytype",
+			expectedRef: "feat/v1.0.0",
+		},
+		{
+			name: "mismatch type with slash",
+			ref:  "refs/mytype/feat/v1.0.0",
+			typ:  "tags",
+			err:  serrors.ErrorInvalidRef,
+		},
+	}
+
+	for i := range testCases {
+		tt := testCases[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ref, err := ValidateGitRef(tt.typ, tt.ref)
+			if diff := cmp.Diff(tt.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if want, got := tt.expectedRef, ref; got != want {
+				t.Fatalf("unexpected ref, got: %q, want: %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the functions `NormalizeGitURI`, `ParseGitURIAndRef`, and `ValidateGitRef`. `ParseGitRef` was updated to be permissive of the ref type whereas `ValidateGitRef` validates that the type is of a given type.

Code extracted from #641 