### PR TITLE
fix: #642: don't use go-cmp for outputting diff

### DIFF
--- a/verifiers/internal/gcb/provenance.go
+++ b/verifiers/internal/gcb/provenance.go
@@ -10,7 +10,6 @@ import (
 
 	"golang.org/x/exp/slices"
 
-	"github.com/google/go-cmp/cmp"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	dsselib "github.com/secure-systems-lab/go-securesystemslib/dsse"
 
@@ -173,8 +172,8 @@ func (p *Provenance) VerifyTextProvenance() error {
 	// they are both taken from a string representation.
 	// We do not use cmp.Equal() because it *can* panic and is intended for unit tests only.
 	if !reflect.DeepEqual(unverifiedTextIntotoStatement, p.verifiedStatement) {
-		return fmt.Errorf("%w: diff '%s'", serrors.ErrorMismatchIntoto,
-			cmp.Diff(unverifiedTextIntotoStatement, p.verifiedStatement))
+		return fmt.Errorf("%w: \nunverified: %v, \nverified: %v", serrors.ErrorMismatchIntoto,
+			unverifiedTextIntotoStatement, p.verifiedStatement)
 	}
 
 	return nil


### PR DESCRIPTION
Previously we used the go-cmp's Diff for displaying a human-friendly diff between two structs in an error message.

I had intended to do a json print of the structs and do a line-by-line diff. There is an internal library for calculating text diff, but I don't see any external functions that expose it to make it available for our use: https://pkg.go.dev/golang.org/x/tools/internal/diff

Instead, this we will simply display both structs in their own "actual" and "expected" sections. The user can use their other tools to find a human-friendly diff.