### PR TITLE
chore: Update doc and digests for v2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You have two options to install the verifier.
 If you want to install the verifier, you can run the following command:
 
 ```bash
-$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.4.1
+$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.5.1
 $ slsa-verifier <options>
 ```
 
@@ -144,7 +144,7 @@ $ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier
 
 ```bash
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ cd slsa-verifier && git checkout v2.4.1
+$ cd slsa-verifier && git checkout v2.5.1
 $ go run ./cli/slsa-verifier <options>
 ```
 
@@ -154,7 +154,7 @@ If you need to install the verifier to run in a GitHub workflow, use the install
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.4.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.4.1)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.5.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.5.1)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,3 +1,13 @@
+### [v2.5.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.5.1)
+
+6246ff80cbd3d272bf843d72d1562cafb7c59b45b5b555fbee92df90547b4256  slsa-verifier-darwin-amd64
+a4da3c85025f31f8a6de09c8261ec1c0793299fd82bc225c9608b0413083354f  slsa-verifier-darwin-arm64
+54e4f40bf120bce1cef1ff123fef3456e8c526f315c47e22ed6acfe02a06b9a8  slsa-verifier-linux-amd64
+5dd8a396c285c4d0d66dcb4eff82c12cd388049106aacd4f2552546f85100064  slsa-verifier-linux-arm64
+e635c8f27d9a485cae3c9846550511fef78ed2b57902ef62ad49d37e1df22e98  slsa-verifier-windows-amd64.exe
+9b08bc2ba25a84e06ecfeecdcabc7e8339da15d272cfd647aa7e3f7f09cb55d5  slsa-verifier-windows-arm64.exe
+
+
 ### [v2.4.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.4.1)
 
 69fa1ea5bb734e765aae1fa855f50e823c2b90b019994610960b7eb3c83feeb3  slsa-verifier-darwin-amd64

--- a/actions/installer/README.md
+++ b/actions/installer/README.md
@@ -11,7 +11,7 @@ For more information about SLSA in general, see [https://slsa.dev](https://slsa.
 To install a specific version of `slsa-verifier`, use:
 
 ```yaml
-uses: slsa-framework/slsa-verifier/actions/installer@v2.4.1
+uses: slsa-framework/slsa-verifier/actions/installer@v2.5.1
 ```
 
 See https://github.com/slsa-framework/slsa-verifier/releases for the list of available `slsa-verifier` releases. Only versions greater or equal to 2.0.1 are supported.


### PR DESCRIPTION
This sets the expected sha256 of the v2.5.1 slsa-verifier released binary.

How to LGTM this PR (I'll work on a proper doc for this in https://github.com/slsa-framework/slsa-github-generator/issues/112):

1. Download the binary and provenance from https://github.com/slsa-framework/slsa-verifier/releases/tag/v0.0.1
2. Clone the slsa-verifier repo, compile and verify the provenance using the steps described in https://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#verify-provenance
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ bash verify-release.sh v2.5.1
```

The output hash should be the hash I'm updating to in this PR. If they match, LGTM. If they don't, someone tampered with the released binary and don't LGTM