### PR TITLE
feat: workflow to update actions dist

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -1,7 +1,7 @@
 # A workflow to run against renovate-bot's PRs,
 # such as `make package` after it updates the package.json and package-lock.json files.
 # The potentially untrusted code is first run inside a low-privilege Job, and the diff is uploaded as an artifact.
-# Then a higher-privilage Job applies the diff and pushes the changes to the PR.
+# Then a higher-privilege Job applies the diff and pushes the changes to the PR.
 # It's important to only run this workflow against PRs from trusted sources, after also reviewing the changes!
 
 name: Post-Commit

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -55,7 +55,7 @@ jobs:
                   [ -z "$(cat ${{ env.ARTIFACT }})" ] && RESULT=false || RESULT=true
                   echo "patch_not_empty=$RESULT" >> "$GITHUB_OUTPUT"
             - name: upload
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
               with:
                   name: ${{ env.ARTIFACT }}
                   path: ${{ env.ARTIFACT }}
@@ -76,7 +76,7 @@ jobs:
               run: |
                   gh pr checkout ${{ inputs.pr_number }}
             - name: download-patch
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
               with:
                   name: ${{ env.ARTIFACT }}
             - id: apply

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -22,16 +22,6 @@ on:
                 required: true
                 type: number
 
-env:
-    COMMAND: |
-        (
-            cd ./actions/installer/dist/../ && \
-            make clean && \
-            make package
-        )
-    COMMIT_MESSAGE: "apply post-commit changes"
-    ARTIFACT: changes.patch
-
 jobs:
     diff:
         permissions:
@@ -48,23 +38,27 @@ jobs:
             - name: checkout-pr
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: |
-                  gh pr checkout ${{ inputs.pr_number }}
+              run: gh pr checkout ${{ inputs.pr_number }}
             - name: run-command
-              run: ${{ env.COMMAND }}
+              run: |
+                (
+                    cd ./actions/installer/dist/../ && \
+                    make clean && \
+                    make package
+                )
             - name: diff
               id: diff
               run: |
                   git add .
                   git status
-                  git diff HEAD > ${{ env.ARTIFACT }}
-                  [ -z "$(cat ${{ env.ARTIFACT }})" ] && RESULT=false || RESULT=true
+                  git diff HEAD > changes.patch
+                  [ -z "$(cat changes.patch)" ] && RESULT=false || RESULT=true
                   echo "patch_not_empty=$RESULT" >> "$GITHUB_OUTPUT"
             - name: upload
               uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
               with:
-                  name: ${{ env.ARTIFACT }}
-                  path: ${{ env.ARTIFACT }}
+                  name: changes.patch
+                  path: changes.patch
 
     push:
         if: needs.diff.outputs.patch_not_empty == 'true'
@@ -79,16 +73,15 @@ jobs:
             - name: checkout-pr
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: |
-                  gh pr checkout ${{ inputs.pr_number }}
+              run: gh pr checkout ${{ inputs.pr_number }}
             - name: download-patch
               uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
               with:
-                  name: ${{ env.ARTIFACT }}
+                  name: changes.patch
             - id: apply
               run: |
-                  git apply ${{ env.ARTIFACT }}
-                  rm ${{ env.ARTIFACT }}
+                  git apply changes.patch
+                  rm changes.patch
             # example from
             # https://github.com/actions/checkout/blob/cd7d8d697e10461458bc61a30d094dc601a8b017/README.md#push-a-commit-using-the-built-in-token
             - name: push
@@ -97,5 +90,5 @@ jobs:
                   git config user.email github-actions@github.com
                   git add .
                   git status
-                  git commit -m "${{ env.COMMIT_MESSAGE }}"
+                  git commit -m "apply post-commit changes"
                   git push

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -1,5 +1,8 @@
 # A workflow to run against renovate-bot's PRs,
 # such as `make package` after it updates the package.json and package-lock.json files.
+# The potentially untrusted code is first run inside a low-privilege Job, and the diff is uploaded as an artifact.
+# Then a higher-privilage Job applies the diff and pushes the changes to the PR.
+# It's important to only run this workflow against PRs from trusted sources, after also reviewing the changes!
 
 name: Post-Commit
 

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -21,8 +21,7 @@ env:
         (
             cd ./actions/installer/dist/../ && \
             make clean && \
-            make package && \
-            true
+            make package
         )
     COMMIT_MESSAGE: "apply post-commit changes"
     ARTIFACT: changes.patch

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -6,8 +6,9 @@
 # It's important to only run this workflow against PRs from trusted sources, after also reviewing the changes!
 
 # There have been vulnerabilities with using `git apply` https://github.blog/2023-04-25-git-security-vulnerabilities-announced-4/
-# At this point a compromised git binary could modify any branch except `main` and `release/*`, due to our branch protection rules and CODEOWNERS.
-# It may also be able to submit a release https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview
+# At this point a compromised git binary cannot modify any of this repo's branches, only the PR fork's branch,
+# due to our branch protection rules and CODEOWNERS.
+# It aslso cannot submit a new release or modify exsiting releases due to tag protection rules.
 
 name: Post-Commit
 

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -90,9 +90,5 @@ jobs:
                   git config user.email github-actions@github.com
                   git add .
                   git status
-                  if git commit -m "${{ env.COMMIT_MESSAGE }}"
-                  then
+                  git commit -m "${{ env.COMMIT_MESSAGE }}"
                   git push
-                  else
-                  echo "there is no diff"
-                  fi

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -1,0 +1,95 @@
+# A workflow to run against renovate-bot's PRs,
+# such as `make package` after it updates the package.json and package-lock.json files.
+
+name: Post-Commit
+
+on:
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: "The pull request number."
+                required: true
+                type: number
+
+env:
+    COMMAND: |
+        (
+            cd ./actions/installer/dist/../ && \
+            make clean && \
+            make package && \
+            true
+        )
+    COMMIT_MESSAGE: "apply post-commit changes"
+    ARTIFACT: changes.patch
+
+jobs:
+    diff:
+        permissions:
+            pull-requests: read
+        outputs:
+            patch_not_empty: ${{ steps.diff.outputs.patch_not_empty }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: checkout
+              uses: actions/checkout@v4
+              with:
+                  repository: ${{ github.repository }}
+                  persist-credentials: false
+            - name: checkout-pr
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  gh pr checkout ${{ inputs.pr_number }}
+            - name: run-command
+              run: ${{ env.COMMAND }}
+            - name: diff
+              id: diff
+              run: |
+                  git add .
+                  git status
+                  git diff HEAD > ${{ env.ARTIFACT }}
+                  [ -z "$(cat ${{ env.ARTIFACT }})" ] && RESULT=false || RESULT=true
+                  echo "patch_not_empty=$RESULT" >> "$GITHUB_OUTPUT"
+            - name: upload
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ env.ARTIFACT }}
+                  path: ${{ env.ARTIFACT }}
+
+    push:
+        if: needs.diff.outputs.patch_not_empty == 'true'
+        needs: diff
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: read
+            contents: write
+        steps:
+            - name: checkout
+              uses: actions/checkout@v4
+            - name: checkout-pr
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  gh pr checkout ${{ inputs.pr_number }}
+            - name: download-patch
+              uses: actions/download-artifact@v4
+              with:
+                  name: ${{ env.ARTIFACT }}
+            - id: apply
+              run: |
+                  git apply ${{ env.ARTIFACT }}
+                  rm ${{ env.ARTIFACT }}
+            # example from
+            # https://github.com/actions/checkout/blob/cd7d8d697e10461458bc61a30d094dc601a8b017/README.md#push-a-commit-using-the-built-in-token
+            - name: push
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com
+                  git add .
+                  git status
+                  if git commit -m "${{ env.COMMIT_MESSAGE }}"
+                  then
+                  git push
+                  else
+                  echo "there is no diff"
+                  fi

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -6,6 +6,8 @@
 
 name: Post-Commit
 
+permissions: {}
+
 on:
     workflow_dispatch:
         inputs:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -1,8 +1,13 @@
 # A workflow to run against renovate-bot's PRs,
 # such as `make package` after it updates the package.json and package-lock.json files.
+
 # The potentially untrusted code is first run inside a low-privilege Job, and the diff is uploaded as an artifact.
 # Then a higher-privilege Job applies the diff and pushes the changes to the PR.
 # It's important to only run this workflow against PRs from trusted sources, after also reviewing the changes!
+
+# There have been vulnerabilities with using `git apply` https://github.blog/2023-04-25-git-security-vulnerabilities-announced-4/
+# At this point a compromised git binary could modify any branch except `main` and `release/*`, due to our branch protection rules and CODEOWNERS.
+# It may also be able to submit a release https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview
 
 name: Post-Commit
 

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
               with:
                   repository: ${{ github.repository }}
                   persist-credentials: false
@@ -71,7 +71,7 @@ jobs:
             contents: write
         steps:
             - name: checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
             - name: checkout-pr
               env:
                   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -92,5 +92,5 @@ jobs:
                   git config user.email github-actions@github.com
                   git add .
                   git status
-                  git commit -m "apply post-commit changes"
+                  git commit -m "update actions dist"
                   git push

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -10,7 +10,7 @@
 # due to our branch protection rules and CODEOWNERS.
 # It aslso cannot submit a new release or modify exsiting releases due to tag protection rules.
 
-name: Post-Commit
+name: Update action dist post-commit
 
 permissions: {}
 

--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -10,7 +10,7 @@
 # due to our branch protection rules and CODEOWNERS.
 # It aslso cannot submit a new release or modify exsiting releases due to tag protection rules.
 
-name: Update action dist post-commit
+name: Update actions dist post-commit
 
 permissions: {}
 
@@ -25,6 +25,7 @@ on:
 jobs:
     diff:
         permissions:
+            # This Job executes the PR's untrusted code, so it must how low permissions.
             pull-requests: read
         outputs:
             patch_not_empty: ${{ steps.diff.outputs.patch_not_empty }}
@@ -65,6 +66,7 @@ jobs:
         needs: diff
         runs-on: ubuntu-latest
         permissions:
+            # This Job does not run untrusted code, but it does need to push changes to the PR's branch.
             pull-requests: read
             contents: write
         steps:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+## Updating Github Actions Dependencies
+
+### Renovate-Bot PRs
+
+`renovate-bot` will periodically send PRs to update the `package.json` and `package-lock.json` in the Github Actions of this repo.
+But, it will not also automatically recompile the packages into `.js` files.
+
+We use a Workflow [Update actions dist post-commit](../.github/workflows/update-actions-dist-post-commit.yml) to 
+help maintainers easily recompile the Github Actions against a PR.
+
+Use the UI to invoke the workflow
+
+[update-actions-dist-post-commit.yml](https://github.com/slsa-framework/slsa-verifier/actions/workflows/update-actions-dist-post-commit.yml)
+
+or invoke with
+
+```shell
+gh workflow run update-actions-dist-post-commit.yml -F pr_number=<pull request number>
+```


### PR DESCRIPTION
Add a new Post-Commit workflow, to make these renovate-bot updates a bit easier.
Previously, we had to clone the PR locally, run `make package`, and then push to the PR.
Now we would just need to use the github UI to invoke this new workflow against the PR number.
We could also copy this over to the slsa-github-generator repo.

> A workflow to run against renovate-bot's PRs,
> such as `make package` after it updates the package.json and package-lock.json files.
> The potentially untrusted code is first run inside a low-privilege Job, and the diff is uploaded as an artifact.
> Then a higher-privilege Job applies the diff and pushes the changes to the PR.
> It's important to only run this workflow against PRs from trusted sources, after also reviewing the changes!

## Testing.

Tested in my own private fork, where when applicable, it pushed a commit of changes to `dist/` folders
- https://github.com/ramonpetgrave64/slsa-verifier/actions/runs/8806815483
  - https://github.com/ramonpetgrave64/slsa-verifier/pull/8/commits
- https://github.com/ramonpetgrave64/slsa-verifier/actions/runs/8806841353
  - https://github.com/ramonpetgrave64/slsa-verifier/pull/16/commits
