### PR TITLE
fix: use pr_number as env variable

### DIFF
--- a/.github/workflows/update-actions-dist-post-commit.yml
+++ b/.github/workflows/update-actions-dist-post-commit.yml
@@ -39,7 +39,8 @@ jobs:
             - name: checkout-pr
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: gh pr checkout ${{ inputs.pr_number }}
+                  PR_NUMBER: ${{ inputs.pr_number }}
+              run: gh pr checkout "$PR_NUMBER"
             - name: run-command
               run: |
                 (
@@ -75,7 +76,8 @@ jobs:
             - name: checkout-pr
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: gh pr checkout ${{ inputs.pr_number }}
+                  PR_NUMBER: ${{ inputs.pr_number }}
+              run: gh pr checkout "$PR_NUMBER"
             - name: download-patch
               uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
               with:


### PR DESCRIPTION
changing the update-dist workflow to use the `pr_number` input as an env variable to avoid [script injection](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks).

Our workflows are only invokable by our trusted maintainers so we should be okay. This is just an extra hardening measure.

Open issue https://github.com/actions/runner/issues/1070#issuecomment-2113287699

## Testing

I confirmed the issue by invoking the workflow with `650 && echo SCRIPT INJECTION`, and it did also do the extra `echo` command.
 - https://github.com/slsa-framework/slsa-verifier/actions/runs/9101350247/job/25018333703#step:3:36

after invoking the workflow again with this PR's version, the problem is mitigated.
 - https://github.com/slsa-framework/slsa-verifier/actions/runs/9101495332/job/25018812710#step:3:8
 - https://github.com/slsa-framework/slsa-verifier/actions/runs/9101516757/job/25018888519#step:3:7 