### PR TITLE
fix: use tag for the builder in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       actions: read # For the detection of GitHub Actions environment.
       id-token: write # For signing.
       contents: write # For asset uploads.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@c747fe7769adf3656dc7d588b161cb614d7abfee # v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.0.0 # always use a tag @X.Y.Z for for slsa builders, not SHA!
     with:
       go-version-file: "go.mod"
       config-file: .slsa-goreleaser/${{matrix.os}}-${{matrix.arch}}.yml


### PR DESCRIPTION
The slsa-github-generator's workflow ref needs to be pinned by tag, not by hash.

Fixes this error

 - https://github.com/slsa-framework/slsa-verifier/actions/runs/9893912259/job/27330429383#step:4:17

```
Verifying slsa-verifier-linux-arm64 using slsa-verifier-linux-arm64.intoto.jsonl
Verified signature against tlog entry index 110869188 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77aa9a66ae8969e055f85c9ec9e0ebbe52e4947cd33cf7b84af120088fe641b8e84
Verifying artifact slsa-verifier-linux-arm64: FAILED: invalid ref: "c747fe7769adf3656dc7d588b161cb614d7abfee": unexpected ref type: ""

FAILED: SLSA verification failed: invalid ref: "c747fe7769adf3656dc7d588b161cb614d7abfee": unexpected ref type: ""
```