### PR TITLE
chore: v2.6.0: update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You have two options to install the verifier.
 If you want to install the verifier, you can run the following command:
 
 ```bash
-$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.5.1
+$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.6.0
 $ slsa-verifier <options>
 ```
 
@@ -148,7 +148,7 @@ $ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier
 
 ```bash
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ cd slsa-verifier && git checkout v2.5.1
+$ cd slsa-verifier && git checkout v2.6.0
 $ go run ./cli/slsa-verifier <options>
 ```
 
@@ -158,7 +158,7 @@ If you need to install the verifier to run in a GitHub workflow, use the install
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.5.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.5.1)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.6.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.6.0)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,3 +1,12 @@
+### [v2.6.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.6.0)
+
+f838adf01bbe62b883e7967167fa827bbf7373f83e2d7727ec18e53f725fee93 slsa-verifier-darwin-amd64
+8740e66832fd48bbaa479acd5310986b876ff545460add0cb4a087aec056189c slsa-verifier-darwin-arm64
+1c9c0d6a272063f3def6d233fa3372adbaff1f5a3480611a07c744e73246b62d slsa-verifier-linux-amd64
+92b28eb2db998f9a6a048336928b29a38cb100076cd587e443ca0a2543d7c93d slsa-verifier-linux-arm64
+37ca29ad748e8ea7be76d3ae766e8fa505362240431f6ea7f0648c727e2f2507 slsa-verifier-windows-amd64.exe
+6235daec8037a2e8f6aa11c583eed6b09b2cd36b61b43b9e5898281b39416d2f slsa-verifier-windows-arm64.exe
+
 ### [v2.5.1](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.5.1)
 
 6246ff80cbd3d272bf843d72d1562cafb7c59b45b5b555fbee92df90547b4256  slsa-verifier-darwin-amd64

--- a/actions/installer/README.md
+++ b/actions/installer/README.md
@@ -11,7 +11,7 @@ For more information about SLSA in general, see [https://slsa.dev](https://slsa.
 To install a specific version of `slsa-verifier`, use:
 
 ```yaml
-uses: slsa-framework/slsa-verifier/actions/installer@v2.5.1
+uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
 ```
 
 See https://github.com/slsa-framework/slsa-verifier/releases for the list of available `slsa-verifier` releases. Only versions greater or equal to 2.0.1 are supported.


### PR DESCRIPTION
#label:release v2.6.0

# How to Verify

Clone the repo and run the script described in https://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#verify-provenance. 
```
$ git clone git@github.com:slsa-framework/slsa-verifier.git
$ cd slsa-verifier
$ bash verify-release.sh v2.6.0
```

This will download the release files and verify the binaries. Confirm that the output hashes matches those in this PR's SHA256SUM.md
 - https://github.com/slsa-framework/slsa-verifier/pull/789/files#diff-7834ca792905514302a0630d1c57dc1d330569a18fc2fff4aac6129efb00f4ccR1-R8