### PR TITLE
chore: Update CODEOWNERS to use teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @laurentsimon @kpk47 @ramonpetgrave64
+* @slsa-framework/tool-maintainers
+* @slsa-framework/slsa-tool-reviewers


### PR DESCRIPTION
This will assign teams rather than individuals to PRs.