### PR TITLE
feat: testing mode from non-main slsa-framework/slsa-github-generator branches

### DIFF
--- a/verifiers/internal/gha/provenance.go
+++ b/verifiers/internal/gha/provenance.go
@@ -330,6 +330,13 @@ func isValidDelegatorBuilderID(prov iface.Provenance) error {
 		}
 	}
 
+	// Exception for slsa-framework/slsa-github-generator branches during testing mode
+	// to allow provenance from non-main to be verified, such as during development.
+	normalizedSLSAGithubGeneratorRepoURI := utils.NormalizeGitURI(httpsGithubCom + trustedBuilderRepository)
+	if options.TestingEnabled() && normalizedURI == utils.NormalizeGitURI(normalizedSLSAGithubGeneratorRepoURI) {
+		return nil
+	}
+
 	return utils.IsValidBuilderTag(builderRef, false)
 }
 

--- a/verifiers/internal/gha/provenance_test.go
+++ b/verifiers/internal/gha/provenance_test.go
@@ -472,6 +472,18 @@ func Test_isValidDelegatorBuilderID(t *testing.T) {
 			testingEnabled: true,
 		},
 		{
+			name: "invalid builder: ref slsa-github-generator repo: testing enabled",
+			sourceURI: gitPrefix + httpsGithubCom + "slsa-framework/slsa-github-generator",
+			builderID: "some/builderID@refs/heads/anybranch",
+			testingEnabled: true,
+		},
+		{
+			name: "invalid builder: ref slsa-github-generator repo: testing disabled",
+			sourceURI: gitPrefix + httpsGithubCom + "slsa-framework/slsa-github-generator",
+			builderID: "some/builderID@refs/heads/anybranch",
+			err: serrors.ErrorInvalidRef,
+		},
+		{
 			name:      "invalid builder ref e2e repo",
 			sourceURI: gitPrefix + httpsGithubCom + e2eTestRepository,
 			builderID: "some/builderID@refs/heads/main",


### PR DESCRIPTION
Allow verifying provenances from the slsa-framework/slsa-github-generator branches.
This is useful during in development.

We could also allow the tester to customize the repo, to perhaps their own fork. example:

```
SLSA_VERIFIER_TESTING_ALTERNATE_SOURCE_REPO="ramonpetgrave64/slsa-verifier" \
    go run . verify-artifact ...
```

## Testing

- Added unit tests
- manually invoking against provenance and artifacts from a test workflow run
  - https://github.com/slsa-framework/slsa-github-generator/actions/runs/10308515370
- also verifying within the same workflow 
  - https://github.com/slsa-framework/slsa-github-generator/actions/runs/10308515370/job/28536184530#step:6:1 