### PR TITLE
chore: update go and golanci lint

### DIFF
--- a/.github/workflows/pre-submit.lint.yml
+++ b/.github/workflows/pre-submit.lint.yml
@@ -16,13 +16,13 @@ jobs:
           go-version-file: "go.mod"
           # not needed but gets rid of warnings
           cache: false
-      - uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
+      - uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         name: golangci-lint
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.59.1
+          version: v1.61.0
 
   yamllint:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ run:
   concurrency: 2
   deadline: 5m
   # For generics.
-  go: 1.18
+  # go: 1.23.1
 issues:
   include:
     - EXC0012
@@ -32,7 +32,7 @@ linters:
     # - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     # TODO(https://github.com/slsa-framework/slsa-verifier/issues/363): Restore linter
     # - gci
     - gochecknoinits

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ run:
   concurrency: 2
   deadline: 5m
   # For generics.
-  # go: 1.23.1
 issues:
   include:
     - EXC0012

--- a/cli/slsa-verifier/main_regression_test.go
+++ b/cli/slsa-verifier/main_regression_test.go
@@ -524,7 +524,6 @@ func Test_runVerifyGHAArtifactPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			// Avoid rate limiting by not running the tests in parallel.
 			// t.Parallel()
@@ -805,7 +804,6 @@ func Test_runVerifyGHAArtifactImage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1267,7 +1265,6 @@ func Test_runVerifyGCBArtifactImage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1432,7 +1429,6 @@ func Test_runVerifyGHAContainerBased(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1958,7 +1954,6 @@ func Test_runVerifyNpmPackage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2023,7 +2018,6 @@ func Test_runVerifyVSA(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cli/slsa-verifier/main_regression_test.go
+++ b/cli/slsa-verifier/main_regression_test.go
@@ -864,7 +864,7 @@ func Test_runVerifyGHAArtifactImage(t *testing.T) {
 
 					outBuilderID, err := cmd.Exec(context.Background(), []string{image})
 					if !errCmp(err, tt.err) {
-						t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
+						t.Error(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 					}
 
 					if err != nil {
@@ -1332,7 +1332,7 @@ func Test_runVerifyGCBArtifactImage(t *testing.T) {
 					outBuilderID, err := cmd.Exec(context.Background(), []string{image})
 
 					if !errCmp(err, tt.err) {
-						t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
+						t.Error(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 					}
 
 					if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slsa-framework/slsa-verifier/v2
 
-go 1.22.0
+go 1.23.1
 
 require (
 	github.com/docker/go v1.5.1-1

--- a/verifiers/internal/gcb/provenance_test.go
+++ b/verifiers/internal/gcb/provenance_test.go
@@ -227,7 +227,7 @@ func Test_VerifyBuilder(t *testing.T) {
 			}
 
 			if err := outBuilderID.MatchesLoose(tt.builderID, false); err != nil {
-				t.Errorf(fmt.Sprintf("matches failed: %v", err))
+				t.Errorf("matches failed: %v", err)
 			}
 		})
 	}

--- a/verifiers/internal/gcb/provenance_test.go
+++ b/verifiers/internal/gcb/provenance_test.go
@@ -215,7 +215,7 @@ func Test_VerifyBuilder(t *testing.T) {
 			}
 			outBuilderID, err := prov.VerifyBuilder(&builderOpts)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 
 			if err != nil {
@@ -313,7 +313,7 @@ func Test_validateBuildType(t *testing.T) {
 			}
 			err = validateBuildType(*builderID, tt.buildType)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -579,7 +579,7 @@ func Test_VerifySourceURI(t *testing.T) {
 			}
 			err = prov.VerifySourceURI(tt.source, *builderID)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -704,7 +704,7 @@ func Test_VerifySignature(t *testing.T) {
 
 			err = prov.VerifySignature()
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -745,7 +745,7 @@ func Test_ProvenanceFromBytes(t *testing.T) {
 
 			_, err = ProvenanceFromBytes(content)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -810,7 +810,7 @@ func Test_VerifySubjectDigest(t *testing.T) {
 
 			err = prov.VerifySubjectDigest(tt.hash)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -889,7 +889,7 @@ func Test_VerifySummary(t *testing.T) {
 			}
 			err = prov.VerifySummary(&provenanceOpts)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -970,7 +970,7 @@ func Test_VerifyMetadata(t *testing.T) {
 			}
 			err = prov.VerifyMetadata(&provenanceOpts)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -1038,7 +1038,7 @@ func Test_VerifyTextProvenance(t *testing.T) {
 			if !tt.alter {
 				err = prov.VerifyTextProvenance()
 				if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-					t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+					t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 				}
 				return
 			}
@@ -1110,7 +1110,7 @@ func Test_VerifyTextProvenance(t *testing.T) {
 
 				err = prov.VerifyTextProvenance()
 				if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-					t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+					t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 				}
 				// Start with the original string value.
 				patch = []byte(strings.Clone(string(cpy)))
@@ -1184,7 +1184,7 @@ func Test_VerifyBranch(t *testing.T) {
 
 			err = prov.VerifyBranch(tt.branch)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -1297,7 +1297,7 @@ func Test_VerifyTag(t *testing.T) {
 
 			err = prov.VerifyTag(tt.tag)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -1496,7 +1496,7 @@ func Test_VerifyVersionedTag(t *testing.T) {
 
 			err = prov.VerifyVersionedTag(tt.tag)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 			}
 		})
 	}

--- a/verifiers/internal/gcb/provenance_test.go
+++ b/verifiers/internal/gcb/provenance_test.go
@@ -189,7 +189,6 @@ func Test_VerifyBuilder(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -304,7 +303,6 @@ func Test_validateBuildType(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -554,7 +552,6 @@ func Test_VerifySourceURI(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -692,7 +689,6 @@ func Test_VerifySignature(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -739,7 +735,6 @@ func Test_ProvenanceFromBytes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -793,7 +788,6 @@ func Test_VerifySubjectDigest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -870,7 +864,6 @@ func Test_VerifySummary(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -952,7 +945,6 @@ func Test_VerifyMetadata(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1023,7 +1015,6 @@ func Test_VerifyTextProvenance(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1171,7 +1162,6 @@ func Test_VerifyBranch(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1285,7 +1275,6 @@ func Test_VerifyTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1485,7 +1474,6 @@ func Test_VerifyVersionedTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/internal/gcb/slsaprovenance/v0.1/provenance_test.go
+++ b/verifiers/internal/gcb/slsaprovenance/v0.1/provenance_test.go
@@ -40,7 +40,6 @@ func Test_New(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -92,7 +91,6 @@ func Test_getSubstitutionsField(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/internal/gcb/slsaprovenance/v0.1/provenance_test.go
+++ b/verifiers/internal/gcb/slsaprovenance/v0.1/provenance_test.go
@@ -50,7 +50,7 @@ func Test_New(t *testing.T) {
 			fmt.Println(string(content))
 			_, err = New(content)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -107,10 +107,10 @@ func Test_getSubstitutionsField(t *testing.T) {
 
 			value, err := getSubstitutionsField(internalParemeters, tt.field)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 			}
 			if err == nil && !cmp.Equal(value, tt.value) {
-				t.Errorf(cmp.Diff(value, tt.value))
+				t.Error(cmp.Diff(value, tt.value))
 			}
 		})
 	}

--- a/verifiers/internal/gcb/slsaprovenance/v1.0/provenance_test.go
+++ b/verifiers/internal/gcb/slsaprovenance/v1.0/provenance_test.go
@@ -41,7 +41,6 @@ func Test_getSubstitutionsField(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/internal/gcb/slsaprovenance/v1.0/provenance_test.go
+++ b/verifiers/internal/gcb/slsaprovenance/v1.0/provenance_test.go
@@ -57,10 +57,10 @@ func Test_getSubstitutionsField(t *testing.T) {
 
 			value, err := getSubstitutionsField(internalParemeters, tt.field)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 			}
 			if err == nil && !cmp.Equal(value, tt.value) {
-				t.Errorf(cmp.Diff(value, tt.value))
+				t.Error(cmp.Diff(value, tt.value))
 			}
 		})
 	}

--- a/verifiers/internal/gha/builder_test.go
+++ b/verifiers/internal/gha/builder_test.go
@@ -371,7 +371,7 @@ func Test_isTrustedDelegatorBuilder(t *testing.T) {
 
 			trustedBuilderID, err := utils.TrustedBuilderIDNew(tt.certBuilderID, true)
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 
 			res := isTrustedDelegatorBuilder(trustedBuilderID, tt.trustedBuilderIDs)
@@ -829,64 +829,64 @@ func Test_GetWorkflowInfoFromCertificate(t *testing.T) {
 	trigger := "workflow_dispatch"
 	encodedTrigger, err := asn1.MarshalWithParams(trigger, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	repo := "org/repo"
 	encodedRepoURI, err := asn1.MarshalWithParams(httpsGithubCom+repo, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	issuer := "the-issuer"
 	encodedIssuer, err := asn1.MarshalWithParams(issuer, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	digest := "abcdef"
 	encodedDigest, err := asn1.MarshalWithParams(digest, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	encodedHosted, err := asn1.MarshalWithParams("github-hosted", "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	hosted := HostedGitHub
 	ref := "refs/tags/v1.2.3"
 	encodedRef, err := asn1.MarshalWithParams(ref, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	sourceID := "12345"
 	encodedSourceID, err := asn1.MarshalWithParams(sourceID, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	sourceOwnerID := "12345"
 	encodedSourceOwnerID, err := asn1.MarshalWithParams(sourceOwnerID, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	buildConfigSha1 := "abcdef"
 	encodedBuildConfigSha1, err := asn1.MarshalWithParams(buildConfigSha1, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	buildConfigPath := "path/to/workflow"
 	encodedBuildConfigURI, err := asn1.MarshalWithParams(httpsGithubCom+repo+"/"+buildConfigPath+"@"+ref, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	invocationID := "9207262"
 	encodedInvocationURI, err := asn1.MarshalWithParams(httpsGithubCom+repo+"/actions/runs/"+invocationID, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	subjectSha1 := "subjectSha1"
 	encodedSubjectSha1, err := asn1.MarshalWithParams(subjectSha1, "utf8")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	tests := []struct {

--- a/verifiers/internal/gha/builder_test.go
+++ b/verifiers/internal/gha/builder_test.go
@@ -376,7 +376,7 @@ func Test_isTrustedDelegatorBuilder(t *testing.T) {
 
 			res := isTrustedDelegatorBuilder(trustedBuilderID, tt.trustedBuilderIDs)
 			if res != tt.result {
-				t.Errorf(cmp.Diff(res, tt.result))
+				t.Error(cmp.Diff(res, tt.result))
 			}
 		})
 	}
@@ -442,7 +442,7 @@ func Test_VerifyCertficateSourceRepository(t *testing.T) {
 			t.Parallel()
 			err := VerifyCertficateSourceRepository(tt.workflow, tt.source)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -611,7 +611,7 @@ func Test_verifyTrustedBuilderID(t *testing.T) {
 			t.Parallel()
 			id, byob, err := verifyTrustedBuilderID(httpsGithubCom+tt.path, tt.tag, tt.id, tt.defaults)
 			if byob != tt.byob {
-				t.Errorf(cmp.Diff(byob, tt.byob))
+				t.Error(cmp.Diff(byob, tt.byob))
 			}
 			if diff := cmp.Diff(tt.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("unexpected error (-want +got):\n%s", diff)
@@ -817,7 +817,7 @@ func Test_verifyTrustedBuilderRef(t *testing.T) {
 
 			err := verifyTrustedBuilderRef(&wf, tt.builderRef)
 			if !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 		})
 	}
@@ -1267,14 +1267,14 @@ func Test_GetWorkflowInfoFromCertificate(t *testing.T) {
 			t.Parallel()
 			workflow, err := GetWorkflowInfoFromCertificate(&tt.cert)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.err, cmpopts.EquateErrors()))
 			}
 			if err != nil {
 				return
 			}
 
 			if !cmp.Equal(*workflow, tt.workflow) {
-				t.Errorf(cmp.Diff(*workflow, tt.workflow))
+				t.Error(cmp.Diff(*workflow, tt.workflow))
 			}
 		})
 	}

--- a/verifiers/internal/gha/builder_test.go
+++ b/verifiers/internal/gha/builder_test.go
@@ -310,7 +310,6 @@ func Test_VerifyBuilderIdentity(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			opts := tt.buildOpts
@@ -367,7 +366,6 @@ func Test_isTrustedDelegatorBuilder(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -440,7 +438,6 @@ func Test_VerifyCertficateSourceRepository(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := VerifyCertficateSourceRepository(tt.workflow, tt.source)
@@ -610,7 +607,6 @@ func Test_verifyTrustedBuilderID(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			id, byob, err := verifyTrustedBuilderID(httpsGithubCom+tt.path, tt.tag, tt.id, tt.defaults)
@@ -807,7 +803,6 @@ func Test_verifyTrustedBuilderRef(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			wf := WorkflowIdentity{
 				SourceRepository: tt.callerRepo,
@@ -1268,7 +1263,6 @@ func Test_GetWorkflowInfoFromCertificate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			workflow, err := GetWorkflowInfoFromCertificate(&tt.cert)
@@ -1326,7 +1320,6 @@ func TestWorkflowIdentity(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			if got, want := tt.workflow.SubjectWorkflowName(), tt.workflowName; got != want {
 				t.Errorf("unexpected subject workflow name, got %q, want %q", got, want)

--- a/verifiers/internal/gha/bundle_test.go
+++ b/verifiers/internal/gha/bundle_test.go
@@ -64,7 +64,6 @@ func Test_verifyBundle(t *testing.T) {
 		*/
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -324,7 +323,6 @@ func Test_matchRekorEntryWithEnvelope(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/internal/gha/bundle_test.go
+++ b/verifiers/internal/gha/bundle_test.go
@@ -75,7 +75,7 @@ func Test_verifyBundle(t *testing.T) {
 			_, err = VerifyProvenanceBundle(ctx, content, trustedRoot)
 
 			if !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}

--- a/verifiers/internal/gha/npm_test.go
+++ b/verifiers/internal/gha/npm_test.go
@@ -71,7 +71,7 @@ func Test_verifyName(t *testing.T) {
 			err := verifyName(tt.actual, tt.expected)
 
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}
@@ -425,7 +425,7 @@ func Test_verifyPublishSubjectName(t *testing.T) {
 			err := verifyPublishSubjectName(tt.att, tt.subject)
 
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -491,7 +491,7 @@ func Test_verifyPublishPredicateName(t *testing.T) {
 			err := verifyPublishPredicateName(tt.att, tt.subject)
 
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -568,7 +568,7 @@ func Test_verifyPublishPredicateVersion(t *testing.T) {
 			err := verifyPublishPredicateVersion(tt.att, tt.version)
 
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -792,7 +792,7 @@ func Test_verifyPackageName(t *testing.T) {
 
 			err = npm.verifyPackageName(&tt.subject)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -869,7 +869,7 @@ func Test_verifyPublishAttestationSubjectDigest(t *testing.T) {
 
 			err = npm.verifyPublishAttestationSubjectDigest(tt.hash)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -951,7 +951,7 @@ func Test_verifyPackageVersion(t *testing.T) {
 
 			err = npm.verifyPackageVersion(&tt.version)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -1060,7 +1060,7 @@ func Test_verifyIntotoTypes(t *testing.T) {
 
 			err := verifyIntotoTypes(tt.att, tt.predicateTypes, tt.payloadType, tt.prefix)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -1148,7 +1148,7 @@ func Test_verifyIntotoHeaders(t *testing.T) {
 
 			err = npm.verifyIntotoHeaders()
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}

--- a/verifiers/internal/gha/npm_test.go
+++ b/verifiers/internal/gha/npm_test.go
@@ -65,7 +65,6 @@ func Test_verifyName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -183,7 +182,6 @@ func Test_verifyPublishSubjectVersion(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -352,7 +350,6 @@ func Test_verifyProvenanceSubjectVersion(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			builderID, err := utils.TrustedBuilderIDNew(tt.builderID, false)
@@ -422,7 +419,6 @@ func Test_verifyPublishSubjectName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -489,7 +485,6 @@ func Test_verifyPublishPredicateName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -567,7 +562,6 @@ func Test_verifyPublishPredicateVersion(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -707,7 +701,6 @@ func Test_verifyProvenanceSubjectName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			builderID, err := utils.TrustedBuilderIDNew(tt.builderID, false)
@@ -763,7 +756,6 @@ func Test_verifyPackageName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -846,7 +838,6 @@ func Test_verifyPublishAttestationSubjectDigest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -924,7 +915,6 @@ func Test_verifyPackageVersion(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1065,7 +1055,6 @@ func Test_verifyIntotoTypes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1128,7 +1117,6 @@ func Test_verifyIntotoHeaders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1197,7 +1185,6 @@ func Test_NpmNew(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1240,7 +1227,6 @@ func Test_verifyPublishAttestationSignature(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1287,7 +1273,6 @@ func Test_verifyProvenanceAttestationSignature(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/internal/gha/provenance_forgeable_test.go
+++ b/verifiers/internal/gha/provenance_forgeable_test.go
@@ -59,7 +59,6 @@ func Test_verifyPublishAttestationSubjectDigestName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -103,7 +102,6 @@ func Test_verifyBuildConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -141,7 +139,6 @@ func Test_verifyResolvedDependencies(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -233,7 +230,6 @@ func Test_verifyCommonMetadata(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -293,7 +289,6 @@ func Test_verifyV02Metadata(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			metadata := tt.metadata || tt.reproducible || tt.parameters ||
@@ -347,7 +342,6 @@ func Test_verifyV02Parameters(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -393,7 +387,6 @@ func Test_verifyV02BuildConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -518,7 +511,6 @@ func Test_verifyMetadata(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -932,7 +924,6 @@ func Test_verifySystemParameters(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1082,7 +1073,6 @@ func Test_verifyProvenanceMatchesCertificate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/internal/gha/provenance_forgeable_test.go
+++ b/verifiers/internal/gha/provenance_forgeable_test.go
@@ -66,7 +66,7 @@ func Test_verifyPublishAttestationSubjectDigestName(t *testing.T) {
 				subjects: tt.subject,
 			}
 			if err := verifyPublishAttestationSubjectDigestName(prov, tt.digestName); !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -109,7 +109,7 @@ func Test_verifyBuildConfig(t *testing.T) {
 				buildTriggerPath: tt.path,
 			}
 			if err := verifyBuildConfig(prov, &tt.workflow); !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -146,7 +146,7 @@ func Test_verifyResolvedDependencies(t *testing.T) {
 				noResolvedDeps: tt.n,
 			}
 			if err := verifyResolvedDependencies(prov); !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -245,7 +245,7 @@ func Test_verifyCommonMetadata(t *testing.T) {
 			}
 
 			if err := verifyCommonMetadata(prov, &tt.workflow); !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -306,7 +306,7 @@ func Test_verifyV02Metadata(t *testing.T) {
 				}
 			}
 			if err := verifyV02Metadata(prov02); !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -351,7 +351,7 @@ func Test_verifyV02Parameters(t *testing.T) {
 			}
 			err := verifyV02Parameters(prov02)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -396,7 +396,7 @@ func Test_verifyV02BuildConfig(t *testing.T) {
 			}
 			err := verifyV02BuildConfig(prov02)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -535,7 +535,7 @@ func Test_verifyMetadata(t *testing.T) {
 			}
 
 			if err := verifyMetadata(prov02, &tt.workflow); !errCmp(err, tt.errV02) {
-				t.Errorf(cmp.Diff(err, tt.errV02))
+				t.Error(cmp.Diff(err, tt.errV02))
 			}
 
 			prov1 := &testProvenanceV1{}
@@ -550,7 +550,7 @@ func Test_verifyMetadata(t *testing.T) {
 			}
 
 			if err := verifyMetadata(prov1, &tt.workflow); !errCmp(err, tt.errV01) {
-				t.Errorf(cmp.Diff(err, tt.errV01))
+				t.Error(cmp.Diff(err, tt.errV01))
 			}
 		})
 	}
@@ -932,7 +932,7 @@ func Test_verifySystemParameters(t *testing.T) {
 			}
 
 			if err := verifySystemParameters(prov, &tt.workflow); !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -1084,7 +1084,7 @@ func Test_verifyProvenanceMatchesCertificate(t *testing.T) {
 			}
 
 			if err := verifyProvenanceMatchesCertificate(prov, &tt.certificateIdentity); !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}

--- a/verifiers/internal/gha/provenance_test.go
+++ b/verifiers/internal/gha/provenance_test.go
@@ -214,7 +214,6 @@ func Test_VerifyDigest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -403,7 +402,6 @@ func Test_verifySourceURI(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -480,7 +478,6 @@ func Test_isValidDelegatorBuilderID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			prov := &testProvenance{
 				builderID: tt.builderID,
@@ -547,7 +544,6 @@ func Test_verifyBuilderIDExactMatch(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -619,7 +615,6 @@ func Test_VerifyBranch(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -741,7 +736,6 @@ func Test_VerifyWorkflowInputs(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -808,7 +802,6 @@ func Test_VerifyTag(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1226,7 +1219,6 @@ func Test_VerifyVersionedTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1299,7 +1291,6 @@ func Test_VerifyProvenance(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			trustedBuilderID, tErr := utils.TrustedBuilderIDNew(tt.trustedBuilderIDName, true)
@@ -1353,7 +1344,6 @@ func Test_VerifyUntrustedProvenance(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			trustedBuilderID, tErr := utils.TrustedBuilderIDNew(tt.trustedBuilderIDName, true)

--- a/verifiers/internal/gha/provenance_test.go
+++ b/verifiers/internal/gha/provenance_test.go
@@ -218,7 +218,7 @@ func Test_VerifyDigest(t *testing.T) {
 			t.Parallel()
 
 			if err := verifyDigest(tt.prov, tt.artifactHash); !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}
@@ -413,7 +413,7 @@ func Test_verifySourceURI(t *testing.T) {
 
 			err := verifySourceURI(prov02, tt.expectedSourceURI)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -493,7 +493,7 @@ func Test_isValidDelegatorBuilderID(t *testing.T) {
 
 			err := isValidDelegatorBuilderID(prov)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -553,7 +553,7 @@ func Test_verifyBuilderIDExactMatch(t *testing.T) {
 
 			err := verifyBuilderIDExactMatch(prov, tt.expectedID)
 			if !errCmp(err, tt.err) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -619,7 +619,7 @@ func Test_VerifyBranch(t *testing.T) {
 			t.Parallel()
 
 			if err := VerifyBranch(tt.prov, tt.branch); !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}
@@ -740,7 +740,7 @@ func Test_VerifyWorkflowInputs(t *testing.T) {
 			t.Parallel()
 
 			if err := VerifyWorkflowInputs(tt.prov, tt.inputs); !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}
@@ -806,7 +806,7 @@ func Test_VerifyTag(t *testing.T) {
 			t.Parallel()
 
 			if err := VerifyTag(tt.prov, tt.tag); !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}
@@ -1223,7 +1223,7 @@ func Test_VerifyVersionedTag(t *testing.T) {
 			t.Parallel()
 
 			if err := VerifyVersionedTag(tt.prov, tt.tag); !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}
@@ -1309,7 +1309,7 @@ func Test_VerifyProvenance(t *testing.T) {
 			}
 
 			if err := VerifyProvenance(env, tt.provenanceOpts, trustedBuilderID, tt.byob, tt.expectedID); !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}
@@ -1362,7 +1362,7 @@ func Test_VerifyUntrustedProvenance(t *testing.T) {
 			}
 
 			if err := VerifyProvenance(env, tt.provenanceOpts, trustedBuilderID, tt.byob, tt.expectedID); errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}

--- a/verifiers/internal/gha/rekor_test.go
+++ b/verifiers/internal/gha/rekor_test.go
@@ -82,7 +82,7 @@ func Test_GetRekorEntries(t *testing.T) {
 
 			_, err := getUUIDsByArtifactDigest(&mClient, tt.artifactHash)
 			if !errCmp(err, tt.expected) {
-				t.Errorf(cmp.Diff(err, tt.expected))
+				t.Error(cmp.Diff(err, tt.expected))
 			}
 		})
 	}

--- a/verifiers/internal/gha/rekor_test.go
+++ b/verifiers/internal/gha/rekor_test.go
@@ -74,7 +74,6 @@ func Test_GetRekorEntries(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/internal/gha/slsaprovenance/slsaprovenance_test.go
+++ b/verifiers/internal/gha/slsaprovenance/slsaprovenance_test.go
@@ -104,7 +104,6 @@ func Test_ProvenanceFromEnvelope(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/internal/vsa/verifier_test.go
+++ b/verifiers/internal/vsa/verifier_test.go
@@ -229,7 +229,6 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeGa6ZCZn0q6WpaUwJrSk+PPYEsca
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -469,7 +468,6 @@ func Test_matchExpectedValues(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -575,7 +573,6 @@ func Test_matchVerifiedLevels(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -644,7 +641,6 @@ func Test_extractSLSALevels(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/verifiers/utils/builder_test.go
+++ b/verifiers/utils/builder_test.go
@@ -72,7 +72,7 @@ func Test_ParseBuilderID(t *testing.T) {
 
 			name, version, err := ParseBuilderID(tt.builderID, tt.needVersion)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 
 			if err != nil {
@@ -80,11 +80,11 @@ func Test_ParseBuilderID(t *testing.T) {
 			}
 
 			if name != tt.builderName {
-				t.Errorf(cmp.Diff(name, tt.builderName))
+				t.Error(cmp.Diff(name, tt.builderName))
 			}
 
 			if version != tt.builderVersion {
-				t.Errorf(cmp.Diff(version, tt.builderVersion))
+				t.Error(cmp.Diff(version, tt.builderVersion))
 			}
 		})
 	}
@@ -170,7 +170,7 @@ func Test_BuilderIDNew(t *testing.T) {
 
 			trustedBuilderID, err := TrustedBuilderIDNew(tt.trustedBuilderID, tt.needVersion)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 
 			if err != nil {
@@ -182,13 +182,13 @@ func Test_BuilderIDNew(t *testing.T) {
 			full := trustedBuilderID.String()
 
 			if name != tt.builderName {
-				t.Errorf(cmp.Diff(tt.builderName, name))
+				t.Error(cmp.Diff(tt.builderName, name))
 			}
 			if version != tt.builderVersion {
-				t.Errorf(cmp.Diff(tt.builderVersion, version))
+				t.Error(cmp.Diff(tt.builderVersion, version))
 			}
 			if full != tt.trustedBuilderID {
-				t.Errorf(cmp.Diff(tt.trustedBuilderID, full))
+				t.Error(cmp.Diff(tt.trustedBuilderID, full))
 			}
 		})
 	}
@@ -423,7 +423,7 @@ func Test_MatchesLoose(t *testing.T) {
 
 			err = trustedBuilderID.MatchesLoose(tt.match, tt.allowRef)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -639,7 +639,7 @@ func Test_MatchesFull(t *testing.T) {
 
 			err = trustedBuilderID.MatchesFull(tt.match, tt.allowRef)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -754,7 +754,7 @@ func Test_IsValidBuilderTag(t *testing.T) {
 			t.Parallel()
 			err := IsValidBuilderTag(tt.ref, tt.testing)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}
@@ -812,7 +812,7 @@ func Test_IsValidJreleaserBuilderTag(t *testing.T) {
 			t.Parallel()
 			err := IsValidJreleaserBuilderTag(tt.ref)
 			if !cmp.Equal(err, tt.err, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.err))
+				t.Error(cmp.Diff(err, tt.err))
 			}
 		})
 	}

--- a/verifiers/utils/builder_test.go
+++ b/verifiers/utils/builder_test.go
@@ -67,7 +67,6 @@ func Test_ParseBuilderID(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -166,7 +165,6 @@ func Test_BuilderIDNew(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -415,7 +413,6 @@ func Test_MatchesLoose(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -632,7 +629,6 @@ func Test_MatchesFull(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -754,8 +750,6 @@ func Test_IsValidBuilderTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := IsValidBuilderTag(tt.ref, tt.testing)
@@ -814,8 +808,6 @@ func Test_IsValidJreleaserBuilderTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := IsValidJreleaserBuilderTag(tt.ref)

--- a/verifiers/utils/dsse_test.go
+++ b/verifiers/utils/dsse_test.go
@@ -40,14 +40,14 @@ func Test_DecodeSignature(t *testing.T) {
 
 			c, err := DecodeSignature(tt.encoded)
 			if !cmp.Equal(err, tt.expected, cmpopts.EquateErrors()) {
-				t.Errorf(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
+				t.Error(cmp.Diff(err, tt.expected, cmpopts.EquateErrors()))
 			}
 			if err != nil {
 				return
 			}
 			cs := string(c)
 			if cs != tt.decoded {
-				t.Errorf(cmp.Diff(cs, tt.decoded))
+				t.Error(cmp.Diff(cs, tt.decoded))
 			}
 		})
 	}

--- a/verifiers/utils/dsse_test.go
+++ b/verifiers/utils/dsse_test.go
@@ -35,7 +35,6 @@ func Test_DecodeSignature(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This PR updates go to 1.23.1 and updates golanci-lint to v1.61.1, while fixing new lint errors.
