### PR TITLE
feat(action): Updating to Node20

### DIFF
--- a/actions/installer/action.yml
+++ b/actions/installer/action.yml
@@ -23,5 +23,5 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR relates to the discussion from https://github.com/slsa-framework/slsa-verifier/issues/806 regarding the Node16 deprecation notice.

There are no changes to the `dist/` folder with the change to Node20 (used `v20.17.0`) - this is completely drop-in.