### PR TITLE
chore: Update docs for v2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You have two options to install the verifier.
 If you want to install the verifier, you can run the following command:
 
 ```bash
-$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.6.0
+$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.0
 $ slsa-verifier <options>
 ```
 
@@ -149,7 +149,7 @@ $ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier
 
 ```bash
 $ git clone git@github.com:slsa-framework/slsa-verifier.git
-$ cd slsa-verifier && git checkout v2.6.0
+$ cd slsa-verifier && git checkout v2.7.0
 $ go run ./cli/slsa-verifier <options>
 ```
 
@@ -159,7 +159,7 @@ If you need to install the verifier to run in a GitHub workflow, use the install
 
 ### Download the binary
 
-Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.6.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.6.0)
+Download the binary from the latest release at [https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.7.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.7.0)
 
 Download the [SHA256SUM.md](https://github.com/slsa-framework/slsa-verifier/blob/main/SHA256SUM.md).
 

--- a/SHA256SUM.md
+++ b/SHA256SUM.md
@@ -1,3 +1,12 @@
+### [v2.7.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.7.0)
+
+36694b43ab23be234add09272e5faf77349d7e267bf65c01dc9bcdf58c4f496e  slsa-verifier-darwin-amd64
+84d9122ce12e0c79080844285fd5c4976407ed3463e434a1b21b0979c46b1e55  slsa-verifier-darwin-arm64
+499befb675efcca9001afe6e5156891b91e71f9c07ab120a8943979f85cc82e6  slsa-verifier-linux-amd64
+dc3845d7605f666a0938389c1c5735230e50b32a547867ffd351fb14df928167  slsa-verifier-linux-arm64
+61ff8b1cca6ac0012b0ba906367836f64a389444766be437df2a69f71285f43b  slsa-verifier-windows-amd64.exe
+ddf58798049599c44caf299b6a9cf8a41760daa94ee208bdae8aa78fc75dcb2b  slsa-verifier-windows-arm64.exe
+
 ### [v2.6.0](https://github.com/slsa-framework/slsa-verifier/releases/tag/v2.6.0)
 
 f838adf01bbe62b883e7967167fa827bbf7373f83e2d7727ec18e53f725fee93 slsa-verifier-darwin-amd64

--- a/actions/installer/README.md
+++ b/actions/installer/README.md
@@ -11,7 +11,7 @@ For more information about SLSA in general, see [https://slsa.dev](https://slsa.
 To install a specific version of `slsa-verifier`, use:
 
 ```yaml
-uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
+uses: slsa-framework/slsa-verifier/actions/installer@v2.7.0
 ```
 
 See https://github.com/slsa-framework/slsa-verifier/releases for the list of available `slsa-verifier` releases. Only versions greater or equal to 2.0.1 are supported.


### PR DESCRIPTION
#label:release v2.7.0

Updates docs to reference the new v2.7.0 release.

**How to verify**

Clone the repo and run the script described in https://github.com/slsa-framework/slsa-verifier/blob/main/RELEASE.md#verify-provenance. 
```
git clone git@github.com:slsa-framework/slsa-verifier.git
cd slsa-verifier
chmod +x verify-release.sh
GH_TOKEN=`gh auth token` bash verify-release.sh v2.7.0
```

Using the temp directory logged from the above command

```
cd <logged temp directory from running verify-release.sh>
sha256sum * | grep -v "intoto"      
36694b43ab23be234add09272e5faf77349d7e267bf65c01dc9bcdf58c4f496e  slsa-verifier-darwin-amd64
84d9122ce12e0c79080844285fd5c4976407ed3463e434a1b21b0979c46b1e55  slsa-verifier-darwin-arm64
499befb675efcca9001afe6e5156891b91e71f9c07ab120a8943979f85cc82e6  slsa-verifier-linux-amd64
dc3845d7605f666a0938389c1c5735230e50b32a547867ffd351fb14df928167  slsa-verifier-linux-arm64
61ff8b1cca6ac0012b0ba906367836f64a389444766be437df2a69f71285f43b  slsa-verifier-windows-amd64.exe
ddf58798049599c44caf299b6a9cf8a41760daa94ee208bdae8aa78fc75dcb2b  slsa-verifier-windows-arm64.exe
```

Confirm your output checksums matches those in this PR's changes for SHA256SUM.md.