### PR TITLE
fix: less parallelism in tests

### DIFF
--- a/cli/slsa-verifier/main_regression_test.go
+++ b/cli/slsa-verifier/main_regression_test.go
@@ -1448,7 +1448,8 @@ func Test_runVerifyGHAContainerBased(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// Avoid rate limiting by not running the tests in parallel.
+			// t.Parallel()
 
 			checkVersions := getBuildersAndVersions(t, "", nil, GHA_ARTIFACT_CONTAINER_BUILDERS)
 


### PR DESCRIPTION
Makes tests less parallel, hopefully avoiding rate-limit issues.

https://github.com/slsa-framework/slsa-verifier/actions/runs/15706985127/job/44255340266#step:6:1324

```log
Verifying artifact testdata/gha_generic/v1.4.0/binary-linux-amd64-workflow_dispatch: FAILED: error searching rekor entries: Post "https://rekor.sigstore.dev/api/v1/log/entries/retrieve": POST https://rekor.sigstore.dev/api/v1/log/entries/retrieve giving up after 1 attempt(s): context deadline exceeded
```